### PR TITLE
Fix NCP SHACL owl:versionIRI to match RDFS PROF constraint resource IDs

### DIFF
--- a/NCP/CurrentRelease/SHACL/AssessedElement-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/AssessedElement-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ ae:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Assessed Element Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "AE";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/AvailabilitySchedule-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/AvailabilitySchedule-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ as:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Availability schedule vocabulary"@en;
-        owl:versionIRI    <2.3/2.3>;
+        owl:versionIRI    <2.3>;
         owl:versionInfo   "2.3.3"@en;
         dcat:keyword      "AS";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/Contingency-AP-Con-Complex-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/Contingency-AP-Con-Complex-SHACL.ttl
@@ -1,6 +1,6 @@
 #Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHO WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License. 
-@base          <https://ap-con.cim4.eu/Contingency-Complex/2.4> .
-@prefix coc:  <https://ap-con.cim4.eu/Contingency-Complex/2.4#> .
+@base          <https://ap-con.cim4.eu/Contingency-Complex/2.3> .
+@prefix coc:  <https://ap-con.cim4.eu/Contingency-Complex/2.3#> .
 @prefix cim:     <https://cim.ucaiug.io/ns#> .
 @prefix cim16:   <http://iec.ch/TC57/2013/CIM-schema-cim16#> .
 @prefix cim17:   <http://iec.ch/TC57/CIM100#> .
@@ -26,9 +26,9 @@ coc:Ontology  rdf:type         owl:Ontology ;
         dcterms:rights            "Copyright"@en ;
         dcterms:rightsHolder      "ENTSO-E"@en ;
         dcterms:title             "Contingency profile custom constraints"@en ;
-        owl:versionIRI        <https://ap-con.cim4.eu/Contingency-Complex/2.4> ;
+        owl:versionIRI        <https://ap-con.cim4.eu/Contingency-Complex/2.3> ;
 		dcterms:license        "https://www.apache.org/licenses/LICENSE-2.0" ;
-        owl:versionInfo       "2.4.0"@en ;
+        owl:versionInfo       "2.3.0"@en ;
         dcat:landingPage      "https://www.entsoe.eu/digital/cim/cim-for-grid-models-exchange/" ;
         dcat:theme            "constraints"@en .
 

--- a/NCP/CurrentRelease/SHACL/Contingency-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/Contingency-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ co:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Contingency Vocabulary"@en;
-        owl:versionIRI    <2.3/2.3>;
+        owl:versionIRI    <2.3>;
         owl:versionInfo   "2.3.4"@en;
         dcat:keyword      "CO";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
@@ -26,7 +26,7 @@ dm:Ontology  rdf:type         owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Dataset metadata vocabulary"@en;
-        owl:versionIRI        <3.0/3.0>;
+        owl:versionIRI        <3.0>;
         owl:versionInfo       "3.0.0"@en;
         dcat:keyword          "DM";
         dcat:theme            "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/EquipmentReliability-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/EquipmentReliability-AP-Con-Simple-SHACL.ttl
@@ -3135,7 +3135,7 @@ er:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Equipment Reliability Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "ER";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/GridDisturbance-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/GridDisturbance-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ gd:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Grid Disturbance vocabulary"@en;
-        owl:versionIRI    <1.1/1.1>;
+        owl:versionIRI    <1.1>;
         owl:versionInfo   "2.2.4"@en;
         dcat:keyword      "GD";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/ImpactAssessmentMatrix-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/ImpactAssessmentMatrix-AP-Con-Simple-SHACL.ttl
@@ -26,7 +26,7 @@ iam:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Impact Assessment Matrix Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "IAM";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/MonitoringArea-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/MonitoringArea-AP-Con-Simple-SHACL.ttl
@@ -26,7 +26,7 @@ ma:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Monitoring area Vocabulary"@en;
-        owl:versionIRI    <2.3/2.3>;
+        owl:versionIRI    <2.3>;
         owl:versionInfo   "2.3.3"@en;
         dcat:keyword      "MA";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/ObjectRegistry-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/ObjectRegistry-AP-Con-Simple-SHACL.ttl
@@ -30,7 +30,7 @@ or:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Object Registry vocabulary"@en;
-        owl:versionIRI    <2.2/2.2>;
+        owl:versionIRI    <2.2>;
         owl:versionInfo   "2.2.5"@en;
         dcat:keyword      "OR";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/PowerSchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/PowerSchedule-AP-Con-Complex-SHACL.ttl
@@ -1,6 +1,6 @@
 #Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHO WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License. 
-@base          <https://ap-con.cim4.eu/PowerSchedule-Complex/2.3> .
-@prefix psc:  <https://ap-con.cim4.eu/PowerSchedule-Complex/2.3#> .
+@base          <https://ap-con.cim4.eu/PowerSchedule-Complex/2.4> .
+@prefix psc:  <https://ap-con.cim4.eu/PowerSchedule-Complex/2.4#> .
 @prefix cim:     <https://cim.ucaiug.io/ns#> .
 @prefix cim16:   <http://iec.ch/TC57/2013/CIM-schema-cim16#> .
 @prefix cim17:   <http://iec.ch/TC57/CIM100#> .
@@ -27,9 +27,9 @@ psc:Ontology  rdf:type         owl:Ontology ;
         dcterms:rights            "Copyright"@en ;
         dcterms:rightsHolder      "ENTSO-E"@en ;
         dcterms:title             "Power schedule profile custom constraints"@en ;
-        owl:versionIRI        <https://ap-con.cim4.eu/PowerSchedule-Complex/2.3> ;
+        owl:versionIRI        <https://ap-con.cim4.eu/PowerSchedule-Complex/2.4> ;
 		dcterms:license        "https://www.apache.org/licenses/LICENSE-2.0" ;
-        owl:versionInfo       "2.3.1"@en ;
+        owl:versionInfo       "2.4.0"@en ;
         dcat:landingPage      "https://www.entsoe.eu/digital/cim/cim-for-grid-models-exchange/" ;
         dcat:theme            "constraints"@en .
 

--- a/NCP/CurrentRelease/SHACL/PowerSchedule-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/PowerSchedule-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ ps:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Power schedule vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "PS";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/PowerSystemProject-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/PowerSystemProject-AP-Con-Simple-SHACL.ttl
@@ -26,7 +26,7 @@ psp:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Power System Project Vocabulary"@en;
-        owl:versionIRI    <2.3/2.3>;
+        owl:versionIRI    <2.3>;
         owl:versionInfo   "2.3.4"@en;
         dcat:keyword      "PSP";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/RemedialAction-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/RemedialAction-AP-Con-Simple-SHACL.ttl
@@ -2804,7 +2804,7 @@ ra:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Remedial action Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "RA";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/RemedialActionSchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/RemedialActionSchedule-AP-Con-Complex-SHACL.ttl
@@ -1,6 +1,6 @@
 #Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHO WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License. 
-@base          <https://ap-con.cim4.eu/RemedialActionScheule-Complex/2.4> .
-@prefix rasc:  <https://ap-con.cim4.eu/RemedialActionScheule-Complex/2.4#> .
+@base          <https://ap-con.cim4.eu/RemedialActionSchedule-Complex/2.4> .
+@prefix rasc:  <https://ap-con.cim4.eu/RemedialActionSchedule-Complex/2.4#> .
 @prefix cim:     <https://cim.ucaiug.io/ns#> .
 @prefix cim16:   <http://iec.ch/TC57/2013/CIM-schema-cim16#> .
 @prefix cim17:   <http://iec.ch/TC57/CIM100#> .
@@ -27,7 +27,7 @@ rasc:Ontology  rdf:type         owl:Ontology ;
         dcterms:rights            "Copyright"@en ;
         dcterms:rightsHolder      "ENTSO-E"@en ;
         dcterms:title             "Remedial Action Schedule profile custom constraints"@en ;
-        owl:versionIRI        <https://ap-con.cim4.eu/RemedialActionScheule-Complex/2.4> ;
+        owl:versionIRI        <https://ap-con.cim4.eu/RemedialActionSchedule-Complex/2.4> ;
 		dcterms:license        "https://www.apache.org/licenses/LICENSE-2.0" ;
         owl:versionInfo       "2.4.0"@en ;
         dcat:landingPage      "https://www.entsoe.eu/digital/cim/cim-for-grid-models-exchange/" ;

--- a/NCP/CurrentRelease/SHACL/RemedialActionSchedule-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/RemedialActionSchedule-AP-Con-Simple-SHACL.ttl
@@ -26,7 +26,7 @@ ras:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Remedial Action Schedule Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "RAS";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/SecurityAnalysisResult-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/SecurityAnalysisResult-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ sar:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Security Analysis Result Vocabulary"@en;
-        owl:versionIRI    <2.5/2.5>;
+        owl:versionIRI    <2.5>;
         owl:versionInfo   "2.5.0"@en;
         dcat:keyword      "SAR";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/SensitivityMatrix-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/SensitivityMatrix-AP-Con-Simple-SHACL.ttl
@@ -26,7 +26,7 @@ sm:Ontology  rdf:type     owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Sensitivity Matrix Vocabulary"@en;
-        owl:versionIRI    <2.3/2.3>;
+        owl:versionIRI    <2.3>;
         owl:versionInfo   "2.3.3"@en;
         dcat:keyword      "SM";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/StateInstructionSchedule-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/StateInstructionSchedule-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ sis:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "State instruction schedule vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "SIS";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/SteadyStateHypothesisSchedule-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/SteadyStateHypothesisSchedule-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ shs:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Steady State Hypothesis Schedule Vocabulary"@en;
-        owl:versionIRI    <1.1/1.1>;
+        owl:versionIRI    <1.1>;
         owl:versionInfo   "1.1.0"@en;
         dcat:keyword      "SHS";
         dcat:theme        "constraint"@en .

--- a/NCP/CurrentRelease/SHACL/SteadyStateInstruction-AP-Con-Simple-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/SteadyStateInstruction-AP-Con-Simple-SHACL.ttl
@@ -28,7 +28,7 @@ ssi:Ontology  rdf:type    owl:Ontology;
         dcterms:publisher     "ENTSO-E"@en;
         dcterms:rightsHolder  "ENTSO-E"@en;
         dcterms:title         "Steady state instruction Vocabulary"@en;
-        owl:versionIRI    <2.4/2.4>;
+        owl:versionIRI    <2.4>;
         owl:versionInfo   "2.4.0"@en;
         dcat:keyword      "SSI";
         dcat:theme        "constraint"@en .


### PR DESCRIPTION
- Remove duplicated version suffix in Simple SHACL versionIRIs (e.g. <2.4/2.4> -> <2.4>), 18 files
- Fix typo RemedialActionScheule -> RemedialActionSchedule in Complex SHACL
- Fix Contingency-Complex version 2.4 -> 2.3 to match RDFS PROF and Simple counterpart
- Fix PowerSchedule-Complex version 2.3 -> 2.4 to match RDFS PROF and Simple counterpart

Fixes https://github.com/entsoe/application-profiles-library/issues/26
Fixes https://github.com/entsoe/application-profiles-library/issues/27
Fixes https://github.com/entsoe/application-profiles-library/issues/28