### PR TITLE
Add GitHub Actions workflow to build release packages

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -1,0 +1,43 @@
+name: Build Release Packages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag for the package (e.g. v1.0.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Schema Package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: echo "version=${{ github.event.release.tag_name || inputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build schema package
+        run: zip -r "Application_Profiles_${{ steps.version.outputs.version }}.zip" CGMES/ NCP/
+
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "Application_Profiles_${{ steps.version.outputs.version }}.zip" --clobber
+
+      - name: Upload workflow artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-package-${{ steps.version.outputs.version }}
+          path: "Application_Profiles_*.zip"


### PR DESCRIPTION
## Summary

- Adds a workflow that builds a single versioned zip (`Application_Profiles_<version>.zip`) containing `CGMES/` and `NCP/` folders with full directory structure
- Triggers on release publish and supports manual workflow dispatch
- On release: uploads zip as release asset
- On manual run: uploads zip as downloadable workflow artifact

Closes #39

## Test plan

- [ ] Run workflow manually via workflow_dispatch with a test version
- [ ] Verify the zip contains `CGMES/` and `NCP/` with full folder structure (CurrentRelease + PastReleases)
- [ ] Create a test release and verify the zip is attached as an asset