### PR TITLE
Add PROF descriptors for CGMES profiles

### DIFF
--- a/CGMES/CurrentRelease/PROF/CGMES-DL-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-DL-PROF.rdf
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Diagram Layout Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the diagram layout profile from IEC 61970-453.</dcterms:description>
+		<dcat:keyword>DL</dcat:keyword>
+		<prof:hasToken>DL</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>5c35281c-faaa-4b32-b513-bda9e5b393a4</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DL-CrossProfileExplicit/constraints/IEC61970-453/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DL-CrossProfileImplicit/constraints/IEC61970-453/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-453/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_DiagramLayout-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Diagram Layout Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_DiagramLayout-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 DiagramLayout-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_DiagramLayout-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 DiagramLayout-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DL-CrossProfileExplicit/constraints/IEC61970-453/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-453_DiagramLayout-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-453 DiagramLayout-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DL-CrossProfileImplicit/constraints/IEC61970-453/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-453_DiagramLayout-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-453 DiagramLayout-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/IEC61970-453/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-453_DiagramLayout-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-453 DiagramLayout-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_DiagramLayout-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 DiagramLayout-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_DiagramLayout-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 DiagramLayout-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-DY-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-DY-PROF.rdf
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Dynamics Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the dynamics profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>DY</dcat:keyword>
+		<prof:hasToken>DY</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>f16c8167-ad8a-4886-9a86-76d89fcbdb64</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariables-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-302/1.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DY-CrossProfileExplicit/constraints/IEC61970-457/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/DY-CrossProfileImplicit/constraints/IEC61970-457/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-457/notSolved/1.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-457/1.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/inverseAssociations/1.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Dynamics-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Dynamics Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-302/1.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-302_Dynamics-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-302 Dynamics-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DY-CrossProfileExplicit/constraints/IEC61970-457/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-457_Dynamics-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-457 Dynamics-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/DY-CrossProfileImplicit/constraints/IEC61970-457/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-457_Dynamics-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-457 Dynamics-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-457/notSolved/1.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-457_Dynamics-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-457 Dynamics-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/IEC61970-457/1.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-457_Dynamics-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-457 Dynamics-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics/constraints/inverseAssociations/1.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Dynamics-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Dynamics-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Dynamics-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Dynamics-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-EQ-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-EQ-PROF.rdf
@@ -1,0 +1,143 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Core Equipment Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the core equipment profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>EQ</dcat:keyword>
+		<prof:hasToken>EQ</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>b30f9e9a-7305-454b-a509-d28e5651d662</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-452/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600-1/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600-2/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/Constraints/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/Constraints/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600/notSolved/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Equipment-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Core Equipment Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_Equipment-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 Equipment-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_Equipment-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 Equipment-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_EquipmentBoundary-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 EquipmentBoundary-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_EquipmentBoundary-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 EquipmentBoundary-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-452/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-452_Equipment-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 Equipment-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-452_Equipment-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 Equipment-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600-1/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-1_Equipment-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-1 Equipment-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Equipment-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Equipment-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600-2/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Equipment-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Equipment-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Equipment-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Equipment-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_EquipmentBoundary-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 EquipmentBoundary-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_EquipmentBoundary-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 EquipmentBoundary-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Equipment-EU/constraints/IEC61970-600/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600_Equipment-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600 Equipment-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-EQBD-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-EQBD-PROF.rdf
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Equipment Boundary Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the equipment boundary profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>EQBD</dcat:keyword>
+		<prof:hasToken>EQBD</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>c651d71d-6d11-4ac3-87d4-bc4489118f5c</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_EquipmentBoundary-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Equipment Boundary Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_EquipmentBoundary-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 EquipmentBoundary-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_EquipmentBoundary-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 EquipmentBoundary-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_EquipmentBoundary-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 EquipmentBoundary-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_EquipmentBoundary-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 EquipmentBoundary-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-FH-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-FH-PROF.rdf
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/FileHeader-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>File Header Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the file header profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>FH</dcat:keyword>
+		<prof:hasToken>FH</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>34e165a5-ff1c-4bb8-9607-813a22077fc1</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/61970-552/ModelDescription/1"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/61970-552/ModelDescription/1/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/61970-552/ModelDescription/Constraints/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/prof10/constraints/IEC61970-600-1/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/61970-552/ModelDescription/1/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Header-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>File Header Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/61970-552/ModelDescription/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-552-Header-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-552-Header-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/prof10/constraints/IEC61970-600-1/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-1_Prof10-Header-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-1 Prof10-Header-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-GL-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-GL-PROF.rdf
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Geographical Location Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the geographical location profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>GL</dcat:keyword>
+		<prof:hasToken>GL</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>9c39d5ca-111c-4fdf-811d-77a07e3b8fce</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/IEC61968-13/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GL-CrossProfileExplicit/constraints/IEC61968-13/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GL-CrossProfileImplicit/constraints/IEC61968-13/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/IEC61970-600-2/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Geographical Location Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/IEC61968-13/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61968-13_GeographicalLocation-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61968-13 GeographicalLocation-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GL-CrossProfileExplicit/constraints/IEC61968-13/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 GeographicalLocation-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GL-CrossProfileImplicit/constraints/IEC61968-13/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 GeographicalLocation-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 GeographicalLocation-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/constraints/IEC61970-600-2/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 GeographicalLocation-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_GeographicalLocation-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 GeographicalLocation-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-OP-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-OP-PROF.rdf
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Operation Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the operation profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>OP</dcat:keyword>
+		<prof:hasToken>OP</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>59b998f8-de06-4b51-bba5-663e7ea5e6a6</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-452/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/OP-CrossProfileExplicit/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/OP-CrossProfileImplicit/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Operation-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Operation-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Operation Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_Operation-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 Operation-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-452/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-452_Operation-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 Operation-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-452_Operation-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 Operation-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/OP-CrossProfileExplicit/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Operation-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Operation-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/OP-CrossProfileImplicit/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Operation-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Operation-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Operation-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Operation-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Operation-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Operation-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Operation-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-SC-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-SC-PROF.rdf
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Short Circuit Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the short circuit profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>SC</dcat:keyword>
+		<prof:hasToken>SC</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>99a006a8-065c-403a-a5e8-478518882507</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SC-CrossProfile/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-452/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-600-2/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_ShortCircuit-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Short Circuit Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_ShortCircuit-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 ShortCircuit-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_ShortCircuit-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 ShortCircuit-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SC-CrossProfile/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-452_ShortCircuit-AP-Con-Complex-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 ShortCircuit-AP-Con-Complex-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-452/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-452_ShortCircuit-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-452 ShortCircuit-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/constraints/IEC61970-600-2/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_ShortCircuit-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 ShortCircuit-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_ShortCircuit-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 ShortCircuit-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-SSH-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-SSH-PROF.rdf
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Steady State Hypothesis Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the steady state hypothesis profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>SSH</dcat:keyword>
+		<prof:hasToken>SSH</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>8faa57aa-fc7b-4970-8ab0-ec77ecbb3430</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-456/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_SteadyStateHypothesis-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Steady State Hypothesis Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_SteadyStateHypothesis-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 SteadyStateHypothesis-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_SteadyStateHypothesis-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 SteadyStateHypothesis-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-456/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_SteadyStateHypothesis-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 SteadyStateHypothesis-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-456_SteadyStateHypothesis-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 SteadyStateHypothesis-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_SteadyStateHypothesis-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 SteadyStateHypothesis-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-SV-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-SV-PROF.rdf
@@ -1,0 +1,101 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariables-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>State Variables Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the state variables profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>SV</dcat:keyword>
+		<prof:hasToken>SV</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>1aab9552-4f50-4fce-997d-cc7505206761</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU#Ontology"/>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariables-EU/constraints/IEC61970-301/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-301/solved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SV-CrossProfileExplicit/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/SV-CrossProfileImplicit/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-456/solved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/StateVariables-EU/Constraints/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_StateVariables-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>State Variables Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariables-EU/constraints/IEC61970-301/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-301_StateVariables-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 StateVariables-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-301/solved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_StateVariables-AP-Con-Complex-SolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 StateVariables-AP-Con-Complex-SolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SV-CrossProfileExplicit/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_StateVariables-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 StateVariables-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/SV-CrossProfileImplicit/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_StateVariables-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 StateVariables-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-456_StateVariables-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 StateVariables-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/IEC61970-456/solved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_StateVariables-AP-Con-Complex-SolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 StateVariables-AP-Con-Complex-SolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariable-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_StateVariables-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 StateVariables-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/StateVariables-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_StateVariables-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 StateVariables-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>

--- a/CGMES/CurrentRelease/PROF/CGMES-TP-PROF.rdf
+++ b/CGMES/CurrentRelease/PROF/CGMES-TP-PROF.rdf
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:role="http://www.w3.org/ns/dx/prof/role/" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="http://www.w3.org/ns/dx/prof">
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU#Ontology">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/Profile"/>
+		<dcterms:title>Topology Vocabulary</dcterms:title>
+		<dcterms:description>This vocabulary is describing the topology profile from IEC 61970-600-2.</dcterms:description>
+		<dcat:keyword>TP</dcat:keyword>
+		<prof:hasToken>TP</prof:hasToken>
+		<dcterms:creator>ENTSO-E</dcterms:creator>
+		<dcterms:publisher>ENTSO-E</dcterms:publisher>
+		<dcterms:rightsHolder>ENTSO-E</dcterms:rightsHolder>
+		<dcterms:license>https://www.apache.org/licenses/LICENSE-2.0</dcterms:license>
+		<dcterms:language>en-GB</dcterms:language>
+		<dcterms:identifier>ed27df78-26d3-460c-a5e8-3a1bc432bc8c</dcterms:identifier>
+		<owl:versionIRI rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/3.0"/>
+		<owl:versionInfo>3.0.0</owl:versionInfo>
+		<prof:isProfileOf rdf:resource="http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Ontology"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/3.0/vocabulary"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-301/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/TP-CrossProfileExplicit/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/TP-CrossProfileImplicit/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-456/notSolved/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-456/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/inverseAssociations/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/Constraints/3.0"/>
+		<prof:hasResource rdf:resource="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-600/notSolved/3.0"/>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/3.0/vocabulary">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/vocabulary"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Topology-AP-Voc-RDFS2020.rdf"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+		<dcterms:title>Topology Vocabulary</dcterms:title>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-301/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-301_Topology-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-301 Topology-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/TP-CrossProfileExplicit/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_Topology-AP-Con-Complex-Explicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 Topology-AP-Con-Complex-Explicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/TP-CrossProfileImplicit/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_Topology-AP-Con-Complex-Implicit-CrossProfile-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 Topology-AP-Con-Complex-Implicit-CrossProfile-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-456/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-456_Topology-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 Topology-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-456/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-456_Topology-AP-Con-Complex-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-456 Topology-AP-Con-Complex-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/inverseAssociations/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Topology-AP-Con-Complex-InverseAssociation-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Topology-AP-Con-Complex-InverseAssociation-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/Constraints/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/constraints"/>
+		<prof:hasArtifact rdf:resource="61970-600-2_Topology-AP-Con-Simple-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600-2 Topology-AP-Con-Simple-SHACL</rdfs:label>
+	</rdf:Description>
+	<rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Topology-EU/constraints/IEC61970-600/notSolved/3.0">
+		<rdf:type rdf:resource="http://www.w3.org/ns/dx/prof/ResourceDescriptor"/>
+		<prof:hasRole rdf:resource="http://www.w3.org/ns/dx/prof/role/validation"/>
+		<prof:hasArtifact rdf:resource="61970-600_Topology-AP-Con-Complex-NotSolvedMAS-SHACL.ttl"/>
+		<dcterms:format rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+		<dcterms:conformsTo>http://www.w3.org/ns/shacl</dcterms:conformsTo>
+		<rdfs:label>61970-600 Topology-AP-Con-Complex-NotSolvedMAS-SHACL</rdfs:label>
+	</rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
## Summary

Add W3C PROF descriptors for all 11 CGMES v3.0 profiles under `CGMES/CurrentRelease/PROF/`.

## Files added

| File | Profile | Vocabulary | Constraints | Validation | Dependencies |
|---|---|---|---|---|---|
| CGMES-EQ-PROF.rdf | Equipment | 1 | 8 | 5 | — |
| CGMES-SSH-PROF.rdf | SteadyStateHypothesis | 1 | 3 | 2 | EQ |
| CGMES-TP-PROF.rdf | Topology | 1 | 4 | 4 | EQ |
| CGMES-SV-PROF.rdf | StateVariables | 1 | 3 | 5 | EQ, SSH, TP |
| CGMES-DY-PROF.rdf | Dynamics | 1 | 2 | 5 | EQ, SSH, SV, TP |
| CGMES-DL-PROF.rdf | DiagramLayout | 1 | 3 | 4 | EQ, TP |
| CGMES-OP-PROF.rdf | Operation | 1 | 3 | 4 | EQ |
| CGMES-SC-PROF.rdf | ShortCircuit | 1 | 4 | 2 | EQ |
| CGMES-GL-PROF.rdf | GeographicalLocation | 1 | 2 | 4 | EQ |
| CGMES-EQBD-PROF.rdf | EquipmentBoundary | 1 | 2 | 2 | EQ |
| CGMES-FH-PROF.rdf | Header | 1 | 2 | 0 | — |

## W3C PROF properties used

- `prof:hasToken` — short profile identifier (EQ, SSH, SV, etc.)
- `prof:isProfileOf` — cross-profile dependencies (e.g., SV depends on EQ, SSH, TP)
- `prof:hasRole` with `role/constraints` — for Simple and Complex SHACL
- `prof:hasRole` with `role/validation` — for CrossProfile, SolvedMAS, and InverseAssociation SHACL
- `prof:hasRole` with `role/vocabulary` — for RDFS files

Fixes #33
Related to #43