### PR TITLE
Fix IdentifiedObject SHACL path subjects

### DIFF
--- a/CGMES/CurrentRelease/SHACL/61970-600-2_IdentifiedObjectCommon_AP-Con-Complex-SHACL.ttl
+++ b/CGMES/CurrentRelease/SHACL/61970-600-2_IdentifiedObjectCommon_AP-Con-Complex-SHACL.ttl
@@ -78,7 +78,7 @@ io:IdentifiedObject.shortName-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>12) .
 			}""" .         
@@ -104,7 +104,7 @@ io:IdentifiedObject.energyIdentCodeEic-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)!=16) .
 			}""" .          
@@ -130,7 +130,7 @@ io:IdentifiedObject.name-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>128) .
 			}""" .        
@@ -156,7 +156,7 @@ io:IdentifiedObject.description-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>256) .
 			}""" .    


### PR DESCRIPTION
## Summary
- Replace `?s $PATH ?value` with `$this $PATH ?value` in the four `IdentifiedObject` SHACL string-length SPARQL constraints called out in the issue.
- Keep the query subject aligned with the selected `$this` focus node.

## Validation
- Confirmed the four issue-referenced lines now use `$this $PATH ?value`.
- Ran `git diff --check`.

Note: I could not run a local Turtle parse because `rdflib` is not installed in this environment.

Closes #76