### PR TITLE
Fix SPARQL HAVING without GROUP BY in two constraint queries

### DIFF
--- a/CGMES/CurrentRelease/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/CurrentRelease/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1464,8 +1464,8 @@ equ:PowerTransformerEnd.ratedS-valueRange2windingSparql
         #OPTIONAL {?end2 cim:PowerTransformerEnd.ratedS  ?ratedsend2 }.
 
         FILTER (?hasvalue=true && ?hasratedsend2=true && ?end1!=?end2 && ?value!=?ratedsend2) .        
+        FILTER (?ends=2) .
 			}
-      HAVING(?ends=2)
       """ .       
       
       

--- a/CGMES/CurrentRelease/SHACL/61970-600-2_AllProfiles-AP-Con-Complex-SolvedMAS-SHACL.ttl
+++ b/CGMES/CurrentRelease/SHACL/61970-600-2_AllProfiles-AP-Con-Complex-SolvedMAS-SHACL.ttl
@@ -98,8 +98,8 @@ sm6002:RegulatingControl-samePointSparql
       }
       GROUP BY $this ?mode
 			}
+      FILTER (?count>1) .
       }
-      HAVING (?count>1)
       #LIMIT 1
       """ .
 


### PR DESCRIPTION
Fixes the `HAVING`-without-`GROUP BY` defect reported in https://github.com/entsoe/application-profiles-library/issues/70#issuecomment-4894091376 (part of the #70 findings).

SPARQL 1.1 defines `HAVING` only over grouped solution sets (§11.3: *"HAVING operates over grouped solution sets, in the same way that FILTER operates over un-grouped ones"*). Both affected queries use a trailing `HAVING` with no `GROUP BY`, no aggregate inside the `HAVING` expression, and a non-aggregate projection — a construct with no conforming interpretation (a grouped reading would also violate the §11.4 projection restriction, which allows only aggregates/constants/group keys to be projected). Engines therefore diverge: rdflib/pySHACL silently treat it like a filter, while strict engines reject the query outright (QLever: `Invalid SPARQL query: A HAVING clause is only supported in queries with GROUP BY`) — so whether these constraints ran at all depended on validator leniency.

**Changes** — semantics-preserving: in both queries the tested variable is computed by an inner `GROUP BY` subquery and is a plain bound variable at the outer level, so the unambiguous equivalent is a `FILTER` at the end of the outer WHERE block:

- `equ:PowerTransformerEnd.ratedS-valueRange2windingSparql` (`61970-301_Equipment-AP-Con-Complex-SHACL.ttl`): `HAVING(?ends=2)` → `FILTER (?ends=2)`
- `sm600-2:RegulatingControl-samePointSparql` (`61970-600-2_AllProfiles-AP-Con-Complex-SolvedMAS-SHACL.ttl`): `HAVING (?count>1)` → `FILTER (?count>1)`

**Verification**: both files parse; validating a full CGMES 3.0 Equipment instance yields identical results before/after the change on rdflib, and QLever now accepts and agrees with both queries.

This addresses only the HAVING defect — the other #70 findings (fake `sh:path rdf:type`, per-instance SPARQL performance) are left to the shape restructuring discussed there. The same two defects are also present on the `cgmes-v3-0` release branch, where this fix applies unchanged.