### PR TITLE
Fix IdentifiedObject SHACL query subjects

### DIFF
--- a/CGMES/CurrentRelease/SHACL/61970-600-2_IdentifiedObjectCommon_AP-Con-Complex-SHACL.ttl
+++ b/CGMES/CurrentRelease/SHACL/61970-600-2_IdentifiedObjectCommon_AP-Con-Complex-SHACL.ttl
@@ -78,7 +78,7 @@ io:IdentifiedObject.shortName-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>12) .
 			}""" .         
@@ -104,7 +104,7 @@ io:IdentifiedObject.energyIdentCodeEic-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)!=16) .
 			}""" .          
@@ -130,7 +130,7 @@ io:IdentifiedObject.name-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>128) .
 			}""" .        
@@ -156,7 +156,7 @@ io:IdentifiedObject.description-stringLengthSparql
 		sh:select """
 			SELECT  $this ?value  
 			WHERE {      
-        ?s $PATH ?value .
+        $this $PATH ?value .
         
         FILTER (STRLEN(?value)>256) .
 			}""" .    


### PR DESCRIPTION
## Summary
- replace the four IdentifiedObject string-length query subjects from ?s to $this in 61970-600-2_IdentifiedObjectCommon_AP-Con-Complex-SHACL.ttl`n
## Validation
- confirmed no ?s  ?value occurrences remain in the target file
- ran git diff --check`n
Fixes #76