### PR TITLE
Fix PowerFlowResult valueA prefix

### DIFF
--- a/NCP/CurrentRelease/SHACL/SecurityAnalysisResult-AP-Con-Complex-SHACL.ttl
+++ b/NCP/CurrentRelease/SHACL/SecurityAnalysisResult-AP-Con-Complex-SHACL.ttl
@@ -328,7 +328,7 @@ sarc:PowerFlowResult-topologicalNodeSparql
         BIND(EXISTS{$this nc:PowerFlowResult.valueW ?o1} AS ?hasvalueW).
 		BIND(EXISTS{$this nc:PowerFlowResult.valueVA ?o2} AS ?hasvalueVA).
 		BIND(EXISTS{$this nc:PowerFlowResult.valueVAR ?o3} AS ?hasvalueVAR).
-		BIND(EXISTS{$this PowerFlowResult.valueA ?o4} AS ?hasvalueA).
+		BIND(EXISTS{$this nc:PowerFlowResult.valueA ?o4} AS ?hasvalueA).
 
         FILTER ( ?hasTN=true && (?hasvalueW=true || ?hasvalueVA=true || ?hasvalueVAR=true || ?hasvalueA=true)).
-			}""" .  			
+			}""" .

--- a/validate/shacl-sparql/PowerFlowResult-topologicalNode.rq
+++ b/validate/shacl-sparql/PowerFlowResult-topologicalNode.rq
@@ -26,7 +26,7 @@ PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
         BIND(EXISTS{$this nc:PowerFlowResult.valueW ?o1} AS ?hasvalueW).
 		BIND(EXISTS{$this nc:PowerFlowResult.valueVA ?o2} AS ?hasvalueVA).
 		BIND(EXISTS{$this nc:PowerFlowResult.valueVAR ?o3} AS ?hasvalueVAR).
-		BIND(EXISTS{$this PowerFlowResult.valueA ?o4} AS ?hasvalueA).
+		BIND(EXISTS{$this nc:PowerFlowResult.valueA ?o4} AS ?hasvalueA).
 
         FILTER ( ?hasTN=true && (?hasvalueW=true || ?hasvalueVA=true || ?hasvalueVAR=true || ?hasvalueA=true)).
 			}


### PR DESCRIPTION
## Summary
- add the missing `nc:` prefix to `PowerFlowResult.valueA` in the `PowerFlowResult-topologicalNode` SPARQL constraint
- update the extracted validation query copy to keep it consistent with the SHACL source
- remove trailing whitespace at the touched SHACL line

## Validation
- `rg -n "\$this\s+PowerFlowResult\.valueA" .` returns no matches
- `git diff --check`

Fixes #84.