### PR TITLE
Fix typos in Dynamics Profile attribute names and cross-references

### DIFF
--- a/CGMES/CurrentRelease/RDFS/61970-600-2_Dynamics-AP-Voc-RDFS2020.rdf
+++ b/CGMES/CurrentRelease/RDFS/61970-600-2_Dynamics-AP-Voc-RDFS2020.rdf
@@ -4451,7 +4451,7 @@ Ref&lt;font color=&quot;#0f0f0f&quot;&gt;erence: IEEE Transactions on Power Appa
 	<rdfs:domain rdf:resource="#GovHydroIEEE0"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gate minimum (&lt;i&gt;Pmin&lt;/i&gt;) (&amp;lt; GovHydroIEEE.pmax). </rdfs:comment>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gate minimum (&lt;i&gt;Pmin&lt;/i&gt;) (&amp;lt; GovHydroIEEE0.pmax). </rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
 	 <rdf:Description rdf:about="#GovHydroIEEE2">
@@ -18932,7 +18932,7 @@ Typical value = true.</rdfs:comment>
 	<rdfs:domain rdf:resource="#ExcDC1A"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimum voltage exciter output limiter (&lt;i&gt;Efdmin&lt;/i&gt;) (&amp;lt; ExcDC1A.edfmax).  Typical value = -99.</rdfs:comment>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimum voltage exciter output limiter (&lt;i&gt;Efdmin&lt;/i&gt;) (&amp;lt; ExcDC1A.efdmax).  Typical value = -99.</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
 	 <rdf:Description rdf:about="#ExcDC1A.efdmax">
@@ -24588,7 +24588,7 @@ This model has 2 input signals. They have the following fixed types (expressed i
 	<rdfs:domain rdf:resource="#PssIEEE4B"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High band output minimum limit (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;Hmin&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PssIEEE4V.vhmax).  Typical value = -0,6.</rdfs:comment>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High band output minimum limit (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;Hmin&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PssIEEE4B.vhmax).  Typical value = -0,6.</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
 	 <rdf:Description rdf:about="#PssIEEE4B.vimax">
@@ -27259,7 +27259,7 @@ Reference: IEEE 421.5-2005, 11.3.</rdfs:comment>
 	<rdfs:domain rdf:resource="#PFVArType1IEEEVArController"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Maximum machine terminal voltage needed for pf/VAr controller to be enabled (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMAX&lt;/sub&gt;&lt;/i&gt;) (&amp;gt; PVFArType1IEEEVArController.vvtmin).</rdfs:comment>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Maximum machine terminal voltage needed for pf/VAr controller to be enabled (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMAX&lt;/sub&gt;&lt;/i&gt;) (&amp;gt; PFVArType1IEEEVArController.vvtmin).</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
 	 <rdf:Description rdf:about="#PFVArType1IEEEVArController.vvtmin">
@@ -27268,7 +27268,7 @@ Reference: IEEE 421.5-2005, 11.3.</rdfs:comment>
 	<rdfs:domain rdf:resource="#PFVArType1IEEEVArController"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimum machine terminal voltage needed to enable pf/var controller (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMIN&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PVFArType1IEEEVArController.vvtmax).</rdfs:comment>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minimum machine terminal voltage needed to enable pf/var controller (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMIN&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PFVArType1IEEEVArController.vvtmax).</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
 	 <rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics-EU#Package_VoltageAdjusterDynamics">

--- a/CGMES/CurrentRelease/RDFS_Beta_501_Ed2_CD/61970-600-2_Dynamics-AP-Voc-RDFSED2a.rdf
+++ b/CGMES/CurrentRelease/RDFS_Beta_501_Ed2_CD/61970-600-2_Dynamics-AP-Voc-RDFSED2a.rdf
@@ -4913,7 +4913,7 @@ Ref&lt;font color=&quot;#0f0f0f&quot;&gt;erence: IEEE Transactions on Power Appa
 	<rdfs:label xml:lang="en">pmin</rdfs:label>
 	<rdfs:domain rdf:resource="#GovHydroIEEE0"/>
 	<rdfs:range rdf:resource = "#PU" />
-	<skos:definition  xml:lang="en">Gate minimum (&lt;i&gt;Pmin&lt;/i&gt;) (&amp;lt; GovHydroIEEE.pmax). </skos:definition>
+	<skos:definition  xml:lang="en">Gate minimum (&lt;i&gt;Pmin&lt;/i&gt;) (&amp;lt; GovHydroIEEE0.pmax). </skos:definition>
 </rdf:Description>
 <rdf:Description rdf:about="#GovHydroIEEE2">
 	<rdfs:label xml:lang="en">GovHydroIEEE2</rdfs:label>
@@ -16456,7 +16456,7 @@ Typical value = true.
 	<rdfs:label xml:lang="en">efdmin</rdfs:label>
 	<rdfs:domain rdf:resource="#ExcDC1A"/>
 	<rdfs:range rdf:resource = "#PU" />
-	<skos:definition  xml:lang="en">Minimum voltage exciter output limiter (&lt;i&gt;Efdmin&lt;/i&gt;) (&amp;lt; ExcDC1A.edfmax).  Typical value = -99.</skos:definition>
+	<skos:definition  xml:lang="en">Minimum voltage exciter output limiter (&lt;i&gt;Efdmin&lt;/i&gt;) (&amp;lt; ExcDC1A.efdmax).  Typical value = -99.</skos:definition>
 </rdf:Description>
 <rdf:Description rdf:about="#ExcDC1A.efdmax">
 	<rdf:type rdf:resource = "http://www.w3.org/2002/07/owl#DatatypeProperty" />
@@ -20958,7 +20958,7 @@ This model has 2 input signals. They have the following fixed types (expressed i
 	<rdfs:label xml:lang="en">vhmin</rdfs:label>
 	<rdfs:domain rdf:resource="#PssIEEE4B"/>
 	<rdfs:range rdf:resource = "#PU" />
-	<skos:definition  xml:lang="en">High band output minimum limit (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;Hmin&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PssIEEE4V.vhmax).  Typical value = -0,6.</skos:definition>
+	<skos:definition  xml:lang="en">High band output minimum limit (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;Hmin&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PssIEEE4B.vhmax).  Typical value = -0,6.</skos:definition>
 </rdf:Description>
 <rdf:Description rdf:about="#PssIEEE4B.vimax">
 	<rdf:type rdf:resource = "http://www.w3.org/2002/07/owl#DatatypeProperty" />
@@ -23106,14 +23106,14 @@ Reference: IEEE 421.5-2005, 11.3.
 	<rdfs:label xml:lang="en">vvtmax</rdfs:label>
 	<rdfs:domain rdf:resource="#PFVArType1IEEEVArController"/>
 	<rdfs:range rdf:resource = "#PU" />
-	<skos:definition  xml:lang="en">Maximum machine terminal voltage needed for pf/VAr controller to be enabled (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMAX&lt;/sub&gt;&lt;/i&gt;) (&amp;gt; PVFArType1IEEEVArController.vvtmin).</skos:definition>
+	<skos:definition  xml:lang="en">Maximum machine terminal voltage needed for pf/VAr controller to be enabled (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMAX&lt;/sub&gt;&lt;/i&gt;) (&amp;gt; PFVArType1IEEEVArController.vvtmin).</skos:definition>
 </rdf:Description>
 <rdf:Description rdf:about="#PFVArType1IEEEVArController.vvtmin">
 	<rdf:type rdf:resource = "http://www.w3.org/2002/07/owl#DatatypeProperty" />
 	<rdfs:label xml:lang="en">vvtmin</rdfs:label>
 	<rdfs:domain rdf:resource="#PFVArType1IEEEVArController"/>
 	<rdfs:range rdf:resource = "#PU" />
-	<skos:definition  xml:lang="en">Minimum machine terminal voltage needed to enable pf/var controller (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMIN&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PVFArType1IEEEVArController.vvtmax).</skos:definition>
+	<skos:definition  xml:lang="en">Minimum machine terminal voltage needed to enable pf/var controller (&lt;i&gt;V&lt;/i&gt;&lt;i&gt;&lt;sub&gt;VTMIN&lt;/sub&gt;&lt;/i&gt;) (&amp;lt; PFVArType1IEEEVArController.vvtmax).</skos:definition>
 </rdf:Description>
 <rdf:Description rdf:about="http://iec.ch/TC57/ns/CIM/Dynamics-EU#Package_VoltageAdjusterDynamics">
 	<rdf:type rdf:resource="http://iec.ch/TC57/ns/CIM/Dynamics-EU#Package"/>

--- a/CGMES/CurrentRelease/SHACL/61970-302_Dynamics-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/CurrentRelease/SHACL/61970-302_Dynamics-AP-Con-Complex-SHACL.ttl
@@ -1887,10 +1887,10 @@ dyu:ExcAC5A.tf1-valueRange
 
 dyu:GovHydroIEEE0.pmin-valueRangePair
         a               sh:PropertyShape ;
-        sh:description  "Gate minimum (Pmin) (< GovHydroIEEE.pmax). " ;
+        sh:description  "Gate minimum (Pmin) (< GovHydroIEEE0.pmax). " ;
         sh:group        dyu:ValueConstraintsGroup ;
-        sh:lessThan     cim:GovHydroIEEE.pmax ;
-        sh:message      "The value is either equal to or greater than GovHydroIEEE.pmax." ;
+        sh:lessThan     cim:GovHydroIEEE0.pmax ;
+        sh:message      "The value is either equal to or greater than GovHydroIEEE0.pmax." ;
         sh:name         "C:302:DY:GovHydroIEEE0.pmin:valueRangePair" ;
         sh:order        821 ;
         sh:path         cim:GovHydroIEEE0.pmin ;
@@ -3301,10 +3301,10 @@ dyu:WindContQPQULimIEC.tufiltql-valueRange
 
 dyu:PFVArType1IEEEVArController.vvtmin-valueRangePair
         a               sh:PropertyShape ;
-        sh:description  "Minimum machine terminal voltage needed to enable pf/var controller (V<sub>VTMIN</sub>) (< PVFArType1IEEEVArController.vvtmax)." ;
+        sh:description  "Minimum machine terminal voltage needed to enable pf/var controller (V<sub>VTMIN</sub>) (< PFVArType1IEEEVArController.vvtmax)." ;
         sh:group        dyu:ValueConstraintsGroup ;
-        sh:lessThan     cim:PVFArType1IEEEVArController.vvtmax ;
-        sh:message      "The value is either equal to or greater than PVFArType1IEEEVArController.vvtmax." ;
+        sh:lessThan     cim:PFVArType1IEEEVArController.vvtmax ;
+        sh:message      "The value is either equal to or greater than PFVArType1IEEEVArController.vvtmax." ;
         sh:name         "C:302:DY:PFVArType1IEEEVArController.vvtmin:valueRangePair" ;
         sh:order        1010 ;
         sh:path         cim:PFVArType1IEEEVArController.vvtmin ;
@@ -5292,10 +5292,10 @@ dyu:ExcST6B.ts-valueRange
 
 dyu:ExcDC1A.efdmin-valueRangePair
         a               sh:PropertyShape ;
-        sh:description  "Minimum voltage exciter output limiter (Efdmin) (< ExcDC1A.edfmax).  Typical value = -99." ;
+        sh:description  "Minimum voltage exciter output limiter (Efdmin) (< ExcDC1A.efdmax).  Typical value = -99." ;
         sh:group        dyu:ValueConstraintsGroup ;
-        sh:lessThan     cim:ExcDC1A.edfmax ;
-        sh:message      "The value is either equal to or greater than ExcDC1A.edfmax." ;
+        sh:lessThan     cim:ExcDC1A.efdmax ;
+        sh:message      "The value is either equal to or greater than ExcDC1A.efdmax." ;
         sh:name         "C:302:DY:ExcDC1A.efdmin:valueRangePair" ;
         sh:order        189 ;
         sh:path         cim:ExcDC1A.efdmin ;
@@ -10348,10 +10348,10 @@ dyu:ExcIEEEST7B.vrmax-valueRange
 
 dyu:PssIEEE4B.vhmin-valueRangePair
         a               sh:PropertyShape ;
-        sh:description  "High band output minimum limit (V<sub>Hmin</sub>) (< PssIEEE4V.vhmax).  Typical value = -0,6." ;
+        sh:description  "High band output minimum limit (V<sub>Hmin</sub>) (< PssIEEE4B.vhmax).  Typical value = -0,6." ;
         sh:group        dyu:ValueConstraintsGroup ;
-        sh:lessThan     cim:PssIEEE4V.vhmax ;
-        sh:message      "The value is either equal to or greater than PssIEEE4V.vhmax." ;
+        sh:lessThan     cim:PssIEEE4B.vhmax ;
+        sh:message      "The value is either equal to or greater than PssIEEE4B.vhmax." ;
         sh:name         "C:302:DY:PssIEEE4B.vhmin:valueRangePair" ;
         sh:order        1136 ;
         sh:path         cim:PssIEEE4B.vhmin ;

--- a/CGMES/PastReleases/v2-4/Enhanced/SHACL/DynamicsProfile.ttl
+++ b/CGMES/PastReleases/v2-4/Enhanced/SHACL/DynamicsProfile.ttl
@@ -298,28 +298,28 @@ dy:ExcDC1A.te-cardinality
         sh:path         cim:ExcDC1A.te;
         sh:severity     sh:Violation .
 
-dy:ExcDC1A.edfmax-datatype
+dy:ExcDC1A.efdmax-datatype
         rdf:type        sh:PropertyShape;
         sh:datatype     xsd:float;
         sh:description  "This constraint validates the datatype of the property (attribute).";
         sh:group        dy:DatatypesGroup;
         sh:message      "The datatype is not literal or it violates the xsd datatype.";
-        sh:name         "ExcDC1A.edfmax-datatype";
+        sh:name         "ExcDC1A.efdmax-datatype";
         sh:nodeKind     sh:Literal;
         sh:order        3322;
-        sh:path         cim:ExcDC1A.edfmax;
+        sh:path         cim:ExcDC1A.efdmax;
         sh:severity     sh:Violation .
 
-dy:ExcDC1A.edfmax-cardinality
+dy:ExcDC1A.efdmax-cardinality
         rdf:type        sh:PropertyShape;
         sh:description  "This constraint validates the cardinality of the property (attribute).";
         sh:group        dy:CardinalityGroup;
         sh:maxCount     1;
         sh:message      "Missing required property (attribute).";
         sh:minCount     1;
-        sh:name         "ExcDC1A.edfmax-cardinality";
+        sh:name         "ExcDC1A.efdmax-cardinality";
         sh:order        4117;
-        sh:path         cim:ExcDC1A.edfmax;
+        sh:path         cim:ExcDC1A.efdmax;
         sh:severity     sh:Violation .
 
 dy:ExcDC1A.ks-datatype
@@ -465,7 +465,7 @@ dy:ExcDC1A-AllowedProperties
         sh:property           [ sh:path  cim:ExcDC1A.exclim ];
         sh:property           [ sh:path  cim:ExcDC1A.ta ];
         sh:property           [ sh:path  cim:ExcDC1A.ks ];
-        sh:property           [ sh:path  cim:ExcDC1A.edfmax ];
+        sh:property           [ sh:path  cim:ExcDC1A.efdmax ];
         sh:property           [ sh:path  cim:ExcDC1A.te ];
         sh:property           [ sh:path  cim:ExcDC1A.vrmax ];
         sh:property           [ sh:path  cim:ExcDC1A.efdmin ];
@@ -478,7 +478,7 @@ dy:ExcDC1A-AllowedProperties
         sh:targetClass        cim:ExcDC1A .
 
 dy:ExcDC1A  rdf:type    sh:NodeShape;
-        sh:property     ido:IdentifiedObject.mRID-datatype , ido:IdentifiedObject.mRID-cardinality , ido:IdentifiedObject.description-datatype , ido:IdentifiedObject.description-cardinality , ido:IdentifiedObject.name-datatype , ido:IdentifiedObject.name-cardinality , dy:DynamicsFunctionBlock.enabled-datatype , dy:DynamicsFunctionBlock.enabled-cardinality , dy:ExcitationSystemDynamics.SynchronousMachineDynamics-cardinality , dy:ExcitationSystemDynamics.PowerSystemStabilizerDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType1Dynamics-cardinality , dy:ExcitationSystemDynamics.VoltageCompensatorDynamics-cardinality , dy:ExcitationSystemDynamics.OverexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.DiscontinuousExcitationControlDynamics-cardinality , dy:ExcitationSystemDynamics.UnderexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType2Dynamics-cardinality , dy:ExcDC1A.tf-datatype , dy:ExcDC1A.tf-cardinality , dy:ExcDC1A.efd2-datatype , dy:ExcDC1A.efd2-cardinality , dy:ExcDC1A.efd1-datatype , dy:ExcDC1A.efd1-cardinality , dy:ExcDC1A.ke-datatype , dy:ExcDC1A.ke-cardinality , dy:ExcDC1A.kf-datatype , dy:ExcDC1A.kf-cardinality , dy:ExcDC1A.tc-datatype , dy:ExcDC1A.tc-cardinality , dy:ExcDC1A.tb-datatype , dy:ExcDC1A.tb-cardinality , dy:ExcDC1A.vrmin-datatype , dy:ExcDC1A.vrmin-cardinality , dy:ExcDC1A.ka-datatype , dy:ExcDC1A.ka-cardinality , dy:ExcDC1A.efdmin-datatype , dy:ExcDC1A.efdmin-cardinality , dy:ExcDC1A.vrmax-datatype , dy:ExcDC1A.vrmax-cardinality , dy:ExcDC1A.seefd1-cardinality , dy:ExcDC1A.seefd1-datatype , dy:ExcDC1A.seefd2-cardinality , dy:ExcDC1A.seefd2-datatype , dy:ExcDC1A.exclim-cardinality , dy:ExcDC1A.exclim-datatype , dy:ExcDC1A.ta-cardinality , dy:ExcDC1A.ta-datatype , dy:ExcDC1A.ks-cardinality , dy:ExcDC1A.ks-datatype , dy:ExcDC1A.edfmax-cardinality , dy:ExcDC1A.edfmax-datatype , dy:ExcDC1A.te-cardinality , dy:ExcDC1A.te-datatype;
+        sh:property     ido:IdentifiedObject.mRID-datatype , ido:IdentifiedObject.mRID-cardinality , ido:IdentifiedObject.description-datatype , ido:IdentifiedObject.description-cardinality , ido:IdentifiedObject.name-datatype , ido:IdentifiedObject.name-cardinality , dy:DynamicsFunctionBlock.enabled-datatype , dy:DynamicsFunctionBlock.enabled-cardinality , dy:ExcitationSystemDynamics.SynchronousMachineDynamics-cardinality , dy:ExcitationSystemDynamics.PowerSystemStabilizerDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType1Dynamics-cardinality , dy:ExcitationSystemDynamics.VoltageCompensatorDynamics-cardinality , dy:ExcitationSystemDynamics.OverexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.DiscontinuousExcitationControlDynamics-cardinality , dy:ExcitationSystemDynamics.UnderexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType2Dynamics-cardinality , dy:ExcDC1A.tf-datatype , dy:ExcDC1A.tf-cardinality , dy:ExcDC1A.efd2-datatype , dy:ExcDC1A.efd2-cardinality , dy:ExcDC1A.efd1-datatype , dy:ExcDC1A.efd1-cardinality , dy:ExcDC1A.ke-datatype , dy:ExcDC1A.ke-cardinality , dy:ExcDC1A.kf-datatype , dy:ExcDC1A.kf-cardinality , dy:ExcDC1A.tc-datatype , dy:ExcDC1A.tc-cardinality , dy:ExcDC1A.tb-datatype , dy:ExcDC1A.tb-cardinality , dy:ExcDC1A.vrmin-datatype , dy:ExcDC1A.vrmin-cardinality , dy:ExcDC1A.ka-datatype , dy:ExcDC1A.ka-cardinality , dy:ExcDC1A.efdmin-datatype , dy:ExcDC1A.efdmin-cardinality , dy:ExcDC1A.vrmax-datatype , dy:ExcDC1A.vrmax-cardinality , dy:ExcDC1A.seefd1-cardinality , dy:ExcDC1A.seefd1-datatype , dy:ExcDC1A.seefd2-cardinality , dy:ExcDC1A.seefd2-datatype , dy:ExcDC1A.exclim-cardinality , dy:ExcDC1A.exclim-datatype , dy:ExcDC1A.ta-cardinality , dy:ExcDC1A.ta-datatype , dy:ExcDC1A.ks-cardinality , dy:ExcDC1A.ks-datatype , dy:ExcDC1A.efdmax-cardinality , dy:ExcDC1A.efdmax-datatype , dy:ExcDC1A.te-cardinality , dy:ExcDC1A.te-datatype;
         sh:targetClass  cim:ExcDC1A .
 
 dy:TurbineGovernorUserDefined.proprietary-datatype
@@ -5557,28 +5557,28 @@ dy:ExcDC3A.efdlim-cardinality
         sh:path         cim:ExcDC3A.efdlim;
         sh:severity     sh:Violation .
 
-dy:ExcDC3A.edfmax-datatype
+dy:ExcDC3A.efdmax-datatype
         rdf:type        sh:PropertyShape;
         sh:datatype     xsd:float;
         sh:description  "This constraint validates the datatype of the property (attribute).";
         sh:group        dy:DatatypesGroup;
         sh:message      "The datatype is not literal or it violates the xsd datatype.";
-        sh:name         "ExcDC3A.edfmax-datatype";
+        sh:name         "ExcDC3A.efdmax-datatype";
         sh:nodeKind     sh:Literal;
         sh:order        3063;
-        sh:path         cim:ExcDC3A.edfmax;
+        sh:path         cim:ExcDC3A.efdmax;
         sh:severity     sh:Violation .
 
-dy:ExcDC3A.edfmax-cardinality
+dy:ExcDC3A.efdmax-cardinality
         rdf:type        sh:PropertyShape;
         sh:description  "This constraint validates the cardinality of the property (attribute).";
         sh:group        dy:CardinalityGroup;
         sh:maxCount     1;
         sh:message      "Missing required property (attribute).";
         sh:minCount     1;
-        sh:name         "ExcDC3A.edfmax-cardinality";
+        sh:name         "ExcDC3A.efdmax-cardinality";
         sh:order        3803;
-        sh:path         cim:ExcDC3A.edfmax;
+        sh:path         cim:ExcDC3A.efdmax;
         sh:severity     sh:Violation .
 
 dy:ExcDC3A.efd2-datatype
@@ -5722,7 +5722,7 @@ dy:ExcDC3A-AllowedProperties
         sh:property           [ sh:path  cim:ExcDC3A.exclim ];
         sh:property           [ sh:path  cim:ExcDC3A.efd1 ];
         sh:property           [ sh:path  cim:ExcDC3A.efd2 ];
-        sh:property           [ sh:path  cim:ExcDC3A.edfmax ];
+        sh:property           [ sh:path  cim:ExcDC3A.efdmax ];
         sh:property           [ sh:path  cim:ExcDC3A.efdlim ];
         sh:property           [ sh:path  cim:ExcDC3A.kr ];
         sh:property           [ sh:path  cim:ExcDC3A.seefd1 ];
@@ -5735,7 +5735,7 @@ dy:ExcDC3A-AllowedProperties
         sh:targetClass        cim:ExcDC3A .
 
 dy:ExcDC3A  rdf:type    sh:NodeShape;
-        sh:property     ido:IdentifiedObject.mRID-datatype , ido:IdentifiedObject.mRID-cardinality , ido:IdentifiedObject.description-datatype , ido:IdentifiedObject.description-cardinality , ido:IdentifiedObject.name-datatype , ido:IdentifiedObject.name-cardinality , dy:DynamicsFunctionBlock.enabled-datatype , dy:DynamicsFunctionBlock.enabled-cardinality , dy:ExcitationSystemDynamics.SynchronousMachineDynamics-cardinality , dy:ExcitationSystemDynamics.PowerSystemStabilizerDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType1Dynamics-cardinality , dy:ExcitationSystemDynamics.VoltageCompensatorDynamics-cardinality , dy:ExcitationSystemDynamics.OverexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.DiscontinuousExcitationControlDynamics-cardinality , dy:ExcitationSystemDynamics.UnderexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType2Dynamics-cardinality , dy:ExcDC3A.efdmin-datatype , dy:ExcDC3A.efdmin-cardinality , dy:ExcDC3A.ks-datatype , dy:ExcDC3A.ks-cardinality , dy:ExcDC3A.ke-datatype , dy:ExcDC3A.ke-cardinality , dy:ExcDC3A.kv-datatype , dy:ExcDC3A.kv-cardinality , dy:ExcDC3A.trh-datatype , dy:ExcDC3A.trh-cardinality , dy:ExcDC3A.te-datatype , dy:ExcDC3A.te-cardinality , dy:ExcDC3A.seefd2-datatype , dy:ExcDC3A.seefd2-cardinality , dy:ExcDC3A.seefd1-datatype , dy:ExcDC3A.seefd1-cardinality , dy:ExcDC3A.kr-datatype , dy:ExcDC3A.kr-cardinality , dy:ExcDC3A.vrmin-cardinality , dy:ExcDC3A.vrmin-datatype , dy:ExcDC3A.vrmax-cardinality , dy:ExcDC3A.vrmax-datatype , dy:ExcDC3A.exclim-cardinality , dy:ExcDC3A.exclim-datatype , dy:ExcDC3A.efd1-cardinality , dy:ExcDC3A.efd1-datatype , dy:ExcDC3A.efd2-cardinality , dy:ExcDC3A.efd2-datatype , dy:ExcDC3A.edfmax-cardinality , dy:ExcDC3A.edfmax-datatype , dy:ExcDC3A.efdlim-cardinality , dy:ExcDC3A.efdlim-datatype;
+        sh:property     ido:IdentifiedObject.mRID-datatype , ido:IdentifiedObject.mRID-cardinality , ido:IdentifiedObject.description-datatype , ido:IdentifiedObject.description-cardinality , ido:IdentifiedObject.name-datatype , ido:IdentifiedObject.name-cardinality , dy:DynamicsFunctionBlock.enabled-datatype , dy:DynamicsFunctionBlock.enabled-cardinality , dy:ExcitationSystemDynamics.SynchronousMachineDynamics-cardinality , dy:ExcitationSystemDynamics.PowerSystemStabilizerDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType1Dynamics-cardinality , dy:ExcitationSystemDynamics.VoltageCompensatorDynamics-cardinality , dy:ExcitationSystemDynamics.OverexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.DiscontinuousExcitationControlDynamics-cardinality , dy:ExcitationSystemDynamics.UnderexcitationLimiterDynamics-cardinality , dy:ExcitationSystemDynamics.PFVArControllerType2Dynamics-cardinality , dy:ExcDC3A.efdmin-datatype , dy:ExcDC3A.efdmin-cardinality , dy:ExcDC3A.ks-datatype , dy:ExcDC3A.ks-cardinality , dy:ExcDC3A.ke-datatype , dy:ExcDC3A.ke-cardinality , dy:ExcDC3A.kv-datatype , dy:ExcDC3A.kv-cardinality , dy:ExcDC3A.trh-datatype , dy:ExcDC3A.trh-cardinality , dy:ExcDC3A.te-datatype , dy:ExcDC3A.te-cardinality , dy:ExcDC3A.seefd2-datatype , dy:ExcDC3A.seefd2-cardinality , dy:ExcDC3A.seefd1-datatype , dy:ExcDC3A.seefd1-cardinality , dy:ExcDC3A.kr-datatype , dy:ExcDC3A.kr-cardinality , dy:ExcDC3A.vrmin-cardinality , dy:ExcDC3A.vrmin-datatype , dy:ExcDC3A.vrmax-cardinality , dy:ExcDC3A.vrmax-datatype , dy:ExcDC3A.exclim-cardinality , dy:ExcDC3A.exclim-datatype , dy:ExcDC3A.efd1-cardinality , dy:ExcDC3A.efd1-datatype , dy:ExcDC3A.efd2-cardinality , dy:ExcDC3A.efd2-datatype , dy:ExcDC3A.efdmax-cardinality , dy:ExcDC3A.efdmax-datatype , dy:ExcDC3A.efdlim-cardinality , dy:ExcDC3A.efdlim-datatype;
         sh:targetClass  cim:ExcDC3A .
 
 dy:WindTurbineType4aIEC.WindContPType4aIEC-valueType

--- a/CGMES/PastReleases/v2-4/Original/RDFS/DynamicsProfileRDFSAugmented-v2_4_15-4Sep2020.rdf
+++ b/CGMES/PastReleases/v2-4/Original/RDFS/DynamicsProfileRDFSAugmented-v2_4_15-4Sep2020.rdf
@@ -17400,9 +17400,9 @@ Typical Value = true.</rdfs:comment>
 	<rdfs:comment  rdf:parseType="Literal">Minimum voltage exciter output limiter (Efdmin).  Typical Value = -99.</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
-	 <rdf:Description rdf:about="#ExcDC1A.edfmax">
+	 <rdf:Description rdf:about="#ExcDC1A.efdmax">
 	<cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
-	<rdfs:label xml:lang="en">edfmax</rdfs:label>
+	<rdfs:label xml:lang="en">efdmax</rdfs:label>
 	<rdfs:domain rdf:resource="#ExcDC1A"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />
@@ -17713,9 +17713,9 @@ false = a lower limit of zero not applied to integrator output.
 Typical Value = true.</rdfs:comment>
 	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 	 </rdf:Description>
-	 <rdf:Description rdf:about="#ExcDC3A.edfmax">
+	 <rdf:Description rdf:about="#ExcDC3A.efdmax">
 	<cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
-	<rdfs:label xml:lang="en">edfmax</rdfs:label>
+	<rdfs:label xml:lang="en">efdmax</rdfs:label>
 	<rdfs:domain rdf:resource="#ExcDC3A"/>
 	<cims:dataType rdf:resource="#PU"/>
 	<cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1" />


### PR DESCRIPTION
Correct edfmax -> efdmax and mismatched class name references (GovHydroIEEE, PVFArType1IEEEVArController, PssIEEE4V) in comments, SHACL constraints, and property paths across current and past Dynamics profile releases.