### PR TITLE
ncp-v2-4-2: backport #99 — DatasetMetadata class linkage via schema:domainIncludes (fixes #92, #104 on this branch)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -75,6 +75,48 @@ It is recommended to use the [new File Header RDFS](https://github.com/entsoe/ap
 # RDF schemas (RDFS)
 The RDFS 2020 export of the RDFS augmented version is based on IEC 61970-501:2006 (Ed1). The package contains RDFS for CGMES v3.0 and NC Profiles. These are the files which file name contains “Voc-RDFS2020”.
 
+## RDFS conventions and the RDFS ↔ SHACL division of responsibility
+
+The RDFS2020 vocabulary is the **self-standing structural schema** of the exchange. It is serialised as flat RDF/XML — one `rdf:Description` per class or attribute, **no nested descriptions and no blank nodes** — and it defines:
+
+- **Classes and attributes** — which classes exist and which attributes each class carries. This structural backbone lives here, and only here.
+- **The class ↔ attribute linkage**, expressed so that reused vocabularies are not altered:
+  - attributes **owned in a CIM namespace** (`https://cim4.eu/ns/dcatcim#`, `https://cim4.eu/ns/Metadata-European#`, `https://cim.ucaiug.io/ns#`, …) use **`rdfs:domain`** — CIM owns the term, so a strict domain is correct;
+  - **reused external terms** (`dcterms:`, `prov:`, `dcat:`, `adms:`, RDF reification) use **`schema:domainIncludes`** — schema.org's non-inferential counterpart to `rdfs:domain`, which records "expected on this class" **without** the RDFS entailment. Asserting `rdfs:domain` on a term the profile does not own is ontology hijacking (`dcterms:title rdfs:domain dcat:Dataset` would entail that every titled resource, including an ontology, is a `dcat:Dataset`); Dublin Core leaves these terms domain-free for exactly that reason. See [#92](https://github.com/entsoe/application-profiles-library/issues/92).
+- **Simple, attribute-local constraints** — datatype (`cims:dataType`) and multiplicity (`cims:multiplicity`).
+
+> **NB — BREAKING for `rdfs:domain`-driven tooling.** For reused external terms the class linkage is now `schema:domainIncludes`, not `rdfs:domain`. Tooling that derives attribute-to-class membership must read both — `rdfs:domain` for CIM-owned terms and `schema:domainIncludes` for external ones. The `https://schema.org/` namespace is declared on the root `rdf:RDF` element.
+
+```xml
+<!-- reused (external) term — non-inferential class linkage, no hijacking -->
+<rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
+  <cims:dataType rdf:resource="#URI"/>
+  <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+  <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
+  <cims:stereotype>dcterms</cims:stereotype>
+  <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Description>
+
+<!-- CIM-owned term — rdfs:domain stays -->
+<rdf:Description rdf:about="https://cim4.eu/ns/Metadata-European#usedSettings">
+  <cims:dataType rdf:resource="#URI"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+  <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Description>
+```
+
+The **Simple** SHACL constraints are generated mechanically from this RDFS (cardinalities and datatypes), so the vocabulary is the single source of truth for the structure. It follows that the structure must not migrate into SHACL: removing structural information from the RDFS without an RDFS-expressible replacement breaks every tool that generates the Simple SHACL, or an exchange schema, from the vocabulary.
+
+**SHACL** carries only what RDFS cannot express — the **Complex** and **Validation** constraints: value ranges, conditional and cross-attribute rules, cross-profile checks and SPARQL-based logic. SHACL is the validation layer; it does not hold the structural backbone.
+
+| Layer | Holds | Examples |
+|---|---|---|
+| **RDFS** (vocabulary) | structure + simple attribute-local constraints | classes, attributes, class↔attribute linkage (`rdfs:domain` / `schema:domainIncludes`), `cims:dataType`, `cims:multiplicity` |
+| **Simple SHACL** | mechanical projection of the RDFS | cardinality and datatype shapes generated from the vocabulary |
+| **Complex / Validation SHACL** | what RDFS cannot express | value ranges, conditionals, cross-profile, SPARQL |
+
+(The IEC 61970-501:Ed2 beta below explores moving these simple constraints fully into SHACL; the RDFS2020 files documented here keep them in the vocabulary.)
+
 In addition a [beta version](https://github.com/entsoe/application-profiles-library/tree/main/CGMES/CurrentRelease/RDFS/Beta_501_Ed2_CD) of application profile based on RDFS specified in the draft IEC 61970-501:Ed2 (see subfolder CGMES\RDFS\Beta_501_Ed2_CD) is provided. The purpose of inclusion of the beta version in the distribution is to enable the review process. 
 
 Please use these files only for information on the direction where RDFS will evolve in that standard and provide feedback that will be discussed in the standardisation process. 

--- a/.github/README.md
+++ b/.github/README.md
@@ -81,14 +81,25 @@ The RDFS2020 vocabulary is the **self-standing structural schema** of the exchan
 
 - **Classes and attributes** — which classes exist and which attributes each class carries. This structural backbone lives here, and only here.
 - **The class ↔ attribute linkage**, expressed so that reused vocabularies are not altered:
-  - attributes **owned in a CIM namespace** (`https://cim4.eu/ns/dcatcim#`, `https://cim4.eu/ns/Metadata-European#`, `https://cim.ucaiug.io/ns#`, …) use **`rdfs:domain`** — CIM owns the term, so a strict domain is correct;
-  - **reused external terms** (`dcterms:`, `prov:`, `dcat:`, `adms:`, RDF reification) use **`schema:domainIncludes`** — schema.org's non-inferential counterpart to `rdfs:domain`, which records "expected on this class" **without** the RDFS entailment. Asserting `rdfs:domain` on a term the profile does not own is ontology hijacking (`dcterms:title rdfs:domain dcat:Dataset` would entail that every titled resource, including an ontology, is a `dcat:Dataset`); Dublin Core leaves these terms domain-free for exactly that reason. See [#92](https://github.com/entsoe/application-profiles-library/issues/92).
+  - attributes **owned in a CIM namespace** (`https://cim4.eu/ns/dcatcim#`, `https://cim4.eu/ns/Metadata-European#`, `https://cim.ucaiug.io/ns#`, …) use **`rdfs:domain`** — CIM owns the term, so a strict domain is correct, even when the domain class is external (e.g. `dcatcim:preferredVersion rdfs:domain dcat:Dataset`);
+  - **reused external terms attached to a class of the same vocabulary** (`dcat:keyword` on `dcat:Dataset`, `rdf:subject`/`rdf:predicate`/`rdf:object` on `rdf:Statement`) also use **`rdfs:domain`** — the linkage stays inside the owner's own vocabulary, so it restates rather than alters the owner's intent (RDF Schema itself declares `rdfs:domain rdf:Statement` for the reification properties);
+  - **reused external terms attached to a foreign class** (`dcterms:`, `prov:`, `adms:` on `dcat:Dataset` or `dcatcim:Statements`) use **`schema:domainIncludes`** — schema.org's non-inferential counterpart to `rdfs:domain`, which records "expected on this class" **without** the RDFS entailment. Asserting `rdfs:domain` on a term the profile does not own is ontology hijacking (`dcterms:title rdfs:domain dcat:Dataset` would entail that every titled resource, including an ontology, is a `dcat:Dataset`); Dublin Core leaves these terms domain-free for exactly that reason. See [#92](https://github.com/entsoe/application-profiles-library/issues/92).
+  - **Exception**: `dcat:startDate` and `dcat:endDate` keep **`schema:domainIncludes`** although property and class share the `dcat:` namespace — DCAT itself declares `rdfs:domain dcterms:PeriodOfTime` for both, so asserting `rdfs:domain dcat:Dataset` would contradict the owner's own declaration. The general test is: `rdfs:domain` may only be asserted where it matches, or at least cannot conflict with, what the owning vocabulary declares.
 - **Simple, attribute-local constraints** — datatype (`cims:dataType`) and multiplicity (`cims:multiplicity`).
 
-> **NB — BREAKING for `rdfs:domain`-driven tooling.** For reused external terms the class linkage is now `schema:domainIncludes`, not `rdfs:domain`. Tooling that derives attribute-to-class membership must read both — `rdfs:domain` for CIM-owned terms and `schema:domainIncludes` for external ones. The `https://schema.org/` namespace is declared on the root `rdf:RDF` element.
+> **NB — BREAKING for `rdfs:domain`-driven tooling.** For reused external terms attached to a foreign class the linkage is now `schema:domainIncludes`, not `rdfs:domain`. Tooling that derives attribute-to-class membership must read both predicates. The `https://schema.org/` namespace is declared on the root `rdf:RDF` element.
 
 ```xml
-<!-- reused (external) term — non-inferential class linkage, no hijacking -->
+<!-- reused external term on a same-vocabulary class — rdfs:domain restates the owner -->
+<rdf:Description rdf:about="http://www.w3.org/ns/dcat#keyword">
+  <cims:dataType rdf:resource="#String"/>
+  <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+  <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
+  <cims:stereotype>dcat</cims:stereotype>
+  <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+</rdf:Description>
+
+<!-- reused external term on a foreign class — non-inferential class linkage, no hijacking -->
 <rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
   <cims:dataType rdf:resource="#URI"/>
   <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>

--- a/NCP/RDFS/DatasetMetadata-AP-Voc-RDFS2020.rdf
+++ b/NCP/RDFS/DatasetMetadata-AP-Voc-RDFS2020.rdf
@@ -336,7 +336,7 @@ dcatcim:hasAlternativeVersion is a specialisation of dcat:hasVersion with the re
 This property is intended for relating a versioned resource to a non-versioned or abstract resource.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:isVersionOf, which makes use of a broader notion of version, including editions and adaptations.</rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#isVersionOf"/>
     <rdfs:label xml:lang="en">hasVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -366,7 +366,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#inSeries">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>A dataset series of which the dataset is part.</rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#seriesMember"/>
     <rdfs:label xml:lang="en">inSeries</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -423,7 +423,7 @@ The identifier is a text string which is assigned to the resource to provide an 
     <rdfs:comment>This resource has a more specific, versioned resource. This property is intended for relating a non-versioned or abstract resource to several versioned resources, e.g., snapshots.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:hasVersion, which makes use of a broader notion of version, including editions and adaptations.</rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#hasVersion"/>
     <rdfs:label xml:lang="en">isVersionOf</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
@@ -450,7 +450,7 @@ Reference to the date that the complete data set was made valid/available.].</rd
 The intended content type of the model, usually the profile keyword. Used to identify what profiles and content is expected in the document, e.g., Equipment, Boundary, SSH, AE, etc. The same keyword is used for different versions of same profile. It can be also used to identify different content based on the same profile.
 For instance, as the equipment profile can be used for both boundary data and equipment not related to boundary, the keyword is different to indicate that boundary data is exchanged. In order to avoid ambiguity the property is not exchanged in cases where the document contains multiple profiles referenced by dcterms:conformsTo.].</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">keyword</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -472,7 +472,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#nextVersion">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>The next version for the resource.</rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#previousVersion"/>
     <rdfs:label xml:lang="en">nextVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -483,7 +483,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
     <rdfs:comment>rdf:object is an instance of rdf:Property that is used to state the object of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">object</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -492,7 +492,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
     <rdfs:comment>rdf:predicate is an instance of rdf:Property that is used to state the predicate of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">predicate</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -516,7 +516,7 @@ This property is used to specify a specific version to be the preference in a ch
 This property is meant to be used to specify a version chain, consisting of snapshots of a resource.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. One of the typical cases here is representing the history of the versions of a dataset that have been released over time.</rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#nextVersion"/>
     <rdfs:label xml:lang="en">previousVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -618,7 +618,7 @@ Typically, rights information includes a statement about various property rights
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#seriesMember">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>A dataset that is member of this series. </rdfs:comment>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#inSeries"/>
     <rdfs:label xml:lang="en">seriesMember</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -675,7 +675,7 @@ The date and time that this model represents, i.e. for which the model is (or wa
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
     <rdfs:comment>rdf:subject is an instance of rdf:Property that is used to state the subject of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">subject</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -686,7 +686,7 @@ The date and time that this model represents, i.e. for which the model is (or wa
 [CIM context: 
 Describes the Market Time Unit (MTU), e.g. hourly, 15 min., etc.]</rdfs:comment>
     <cims:dataType rdf:resource="#Duration"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">temporalResolution</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -731,7 +731,7 @@ The human readable name of the dataset that can form the instance file name.]</r
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#version">
     <rdfs:comment>The version indicator (name or identifier) of a resource.</rdfs:comment>
     <cims:dataType rdf:resource="#Version"/>
-    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">version</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>

--- a/NCP/RDFS/DatasetMetadata-AP-Voc-RDFS2020.rdf
+++ b/NCP/RDFS/DatasetMetadata-AP-Voc-RDFS2020.rdf
@@ -14,6 +14,7 @@
     xmlns:dcatcim="https://cim4.eu/ns/dcatcim#"
     xmlns:dm="https://ap-voc.cim4.eu/DatasetMetadata#"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
+    xmlns:schema="https://schema.org/"
   xml:base="https://cim.ucaiug.io/ns" > 
   <rdf:Description rdf:about="https://ap-voc.cim4.eu/DatasetMetadata#Ontology">
     <dcterms:conformsTo>urn:iso:std:iec:61970-501:draft:ed-2</dcterms:conformsTo>
@@ -189,6 +190,7 @@ IRIs are a generalization of URIs [RFC3986] that permits a wider range of Unicod
 [CIM context:
 Reference to the confidentiality level that shall be applied when handling this model.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">accessRights</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype>dcterms</cims:stereotype>
@@ -200,6 +202,7 @@ Reference to the confidentiality level that shall be applied when handling this 
 [CIM context:
 Reference to the time frame.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">accrualPeriodicity</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype>dcterms</cims:stereotype>
@@ -238,6 +241,7 @@ dcatcim:alternativeVersionOf is a specialisation of dcat:isVersionOf with the re
 An IRI describing the profile that governs this model. It uniquely identifies the profile and its version. Multiple instances of the property describe all standards or specifications to which the model and the document representing this model conform to.
 A document would normally conform to profile definitions, the constraints that relate to the profile and/or the set of business specific constrains. A reference to a machine- readable constraints or specification indicates that the document was tested against these constraints and it conforms to them.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">conformsTo</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..n"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -248,7 +252,7 @@ A document would normally conform to profile definitions, the constraints that r
     <rdfs:comment>A free-text account of the resource.
 Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</rdfs:comment>
     <cims:dataType rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#LangString"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">description</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -260,7 +264,7 @@ Description may include but is not limited to: an abstract, a table of contents,
 [CIM context:
 The end date and time of the validity period of the model that it is serialized in the document where the header is located. It is only used in relation to the startDate property which indicates the beginning of the validity period of the model.].</rdfs:comment>
     <cims:dataType rdf:resource="https://cim4.eu/ns/Metadata-European#DateTimeStamp"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">endDate</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -282,7 +286,7 @@ The end date and time of the validity period of the model that it is serialized 
 [CIM context:
 The date and time when the model was serialized in the document where the header is located. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC.].</rdfs:comment>
     <cims:dataType rdf:resource="https://cim4.eu/ns/Metadata-European#DateTimeStamp"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">generatedAtTime</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -307,7 +311,7 @@ dcatcim:hasAlternativeVersion is a specialisation of dcat:hasVersion with the re
   <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>The dataset which is part of another dataset.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/isPartOf"/>
     <rdfs:label xml:lang="en">hasPart</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -332,7 +336,7 @@ dcatcim:hasAlternativeVersion is a specialisation of dcat:hasVersion with the re
 This property is intended for relating a versioned resource to a non-versioned or abstract resource.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:isVersionOf, which makes use of a broader notion of version, including editions and adaptations.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#isVersionOf"/>
     <rdfs:label xml:lang="en">hasVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -351,8 +355,8 @@ If a model is serialized as complete (full) model or as difference model exchang
 The identifier might be used as part of the IRI of the resource, but still having it represented explicitly is useful.
 The identifier is a text string which is assigned to the resource to provide an unambiguous reference within a particular context.</rdfs:comment>
     <cims:dataType rdf:resource="#UUID"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-    <rdfs:domain rdf:resource="https://cim4.eu/ns/dcatcim#Statements"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="https://cim4.eu/ns/dcatcim#Statements"/>
     <rdfs:label xml:lang="en">identifier</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -362,7 +366,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#inSeries">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>A dataset series of which the dataset is part.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#seriesMember"/>
     <rdfs:label xml:lang="en">inSeries</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -373,7 +377,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://purl.org/dc/terms/isPartOf">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>The dataset which this datatset is part of.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/hasPart"/>
     <rdfs:label xml:lang="en">isPartOf</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -384,7 +388,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://purl.org/dc/terms/isReferencedBy">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>A related resource, such as a publication, that references, cites, or otherwise points to the cataloged resource.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/references"/>
     <rdfs:label xml:lang="en">isReferencedBy</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -395,7 +399,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://purl.org/dc/terms/isReplacedBy">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>A related resource that supplants, displaces, or supersedes the described resource.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/replaces"/>
     <rdfs:label xml:lang="en">isReplacedBy</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -406,7 +410,7 @@ The identifier is a text string which is assigned to the resource to provide an 
   <rdf:Description rdf:about="http://purl.org/dc/terms/isRequiredBy">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>A related resource that requires the described resource to support its function, delivery, or coherence.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/references"/>
     <rdfs:label xml:lang="en">isRequiredBy</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -419,7 +423,7 @@ The identifier is a text string which is assigned to the resource to provide an 
     <rdfs:comment>This resource has a more specific, versioned resource. This property is intended for relating a non-versioned or abstract resource to several versioned resources, e.g., snapshots.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. Therefore, its semantics is more specific than its super-property dcterms:hasVersion, which makes use of a broader notion of version, including editions and adaptations.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#hasVersion"/>
     <rdfs:label xml:lang="en">isVersionOf</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
@@ -433,7 +437,7 @@ Recommended practice is to describe the date, date/time, or period of time as re
 [CIM context:
 Reference to the date that the complete data set was made valid/available.].</rdfs:comment>
     <cims:dataType rdf:resource="#DateTime"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">issued</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -446,7 +450,7 @@ Reference to the date that the complete data set was made valid/available.].</rd
 The intended content type of the model, usually the profile keyword. Used to identify what profiles and content is expected in the document, e.g., Equipment, Boundary, SSH, AE, etc. The same keyword is used for different versions of same profile. It can be also used to identify different content based on the same profile.
 For instance, as the equipment profile can be used for both boundary data and equipment not related to boundary, the keyword is different to indicate that boundary data is exchanged. In order to avoid ambiguity the property is not exchanged in cases where the document contains multiple profiles referenced by dcterms:conformsTo.].</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">keyword</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -458,6 +462,7 @@ For instance, as the equipment profile can be used for both boundary data and eq
 [CIM context:
 Reference to the license under which the data is made available. If no license holder is defined, then the original data provider holds the license.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">license</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -467,7 +472,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#nextVersion">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>The next version for the resource.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#previousVersion"/>
     <rdfs:label xml:lang="en">nextVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -478,7 +483,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
     <rdfs:comment>rdf:object is an instance of rdf:Property that is used to state the object of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">object</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -487,7 +492,7 @@ Reference to the license under which the data is made available. If no license h
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
     <rdfs:comment>rdf:predicate is an instance of rdf:Property that is used to state the predicate of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">predicate</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -511,7 +516,7 @@ This property is used to specify a specific version to be the preference in a ch
 This property is meant to be used to specify a version chain, consisting of snapshots of a resource.
 
 The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle. One of the typical cases here is representing the history of the versions of a dataset that have been released over time.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#nextVersion"/>
     <rdfs:label xml:lang="en">previousVersion</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
@@ -522,6 +527,7 @@ The notion of version used by this property is limited to versions resulting fro
   <rdf:Description rdf:about="https://cim4.eu/ns/Metadata-European#processType">
     <rdfs:comment>The exact business nature. Reference to Business Process configurations.</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">processType</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -534,6 +540,7 @@ The notion of version used by this property is limited to versions resulting fro
 [CIM context: 
 The agent that is publishing the dataset on the given platform.]</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">publisher</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -545,7 +552,7 @@ The agent that is publishing the dataset on the given platform.]</rdfs:comment>
     <rdfs:comment>A related resource that is referenced, cited, or otherwise pointed to by the described resource[.
 [CIM context: 
 The referenced resource that is being complemented in this dataset, e.g. SSH is referencing EQ.]</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/isReferencedBy"/>
     <rdfs:label xml:lang="en">references</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -558,7 +565,7 @@ The referenced resource that is being complemented in this dataset, e.g. SSH is 
     <rdfs:comment>A related resource that is supplanted, displaced, or superseded by the described resource
 [CIM context: 
 The referenced dataset is being replaced by this dataset.]</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/isReplacedBy"/>
     <rdfs:label xml:lang="en">replaces</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -569,7 +576,7 @@ The referenced dataset is being replaced by this dataset.]</rdfs:comment>
   <rdf:Description rdf:about="http://purl.org/dc/terms/requires">
     <cims:AssociationUsed>Yes</cims:AssociationUsed>
     <rdfs:comment>A related resource that is required by the described resource to support its function, delivery, or coherence.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://purl.org/dc/terms/isRequiredBy"/>
     <rdfs:label xml:lang="en">requires</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -590,7 +597,7 @@ The referenced dataset is being replaced by this dataset.]</rdfs:comment>
   <rdf:Description rdf:about="http://purl.org/dc/terms/rights">
     <rdfs:comment>A statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">rights</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -601,7 +608,7 @@ The referenced dataset is being replaced by this dataset.]</rdfs:comment>
     <rdfs:comment>Information about rights held in and over the resource.
 Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">rightsHolder</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -611,7 +618,7 @@ Typically, rights information includes a statement about various property rights
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#seriesMember">
     <cims:AssociationUsed>No</cims:AssociationUsed>
     <rdfs:comment>A dataset that is member of this series. </rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <cims:inverseRoleName rdf:resource="http://www.w3.org/ns/dcat#inSeries"/>
     <rdfs:label xml:lang="en">seriesMember</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
@@ -623,6 +630,7 @@ Typically, rights information includes a statement about various property rights
     <rdfs:comment>A related resource from which the described resource is derived.
 This property is intended to be used with non-literal values. The described resource may be derived from the related resource in whole or in part. Best practice is to identify the related resource by means of a URI or a string conforming to a formal identification system.</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">source</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -635,6 +643,7 @@ This property is intended to be used with non-literal values. The described reso
 [CIM context: 
 The responsibility area that multiple model can describe, also referred to frame.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">spatial</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -646,7 +655,7 @@ The responsibility area that multiple model can describe, also referred to frame
 [CIM context:
 The date and time that this model represents, i.e. for which the model is (or was) valid. It indicates the beginning of the validity period. It is indicating either an instant (in cases where the model is only valid for a point in time) or the start time of a period. If not provided the model is considered valid for any time stamp. The format is an extended format according to the ISO 8601-2005. European exchanges shall refer to UTC.].</rdfs:comment>
     <cims:dataType rdf:resource="https://cim4.eu/ns/Metadata-European#DateTimeStamp"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">startDate</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -666,7 +675,7 @@ The date and time that this model represents, i.e. for which the model is (or wa
   <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
     <rdfs:comment>rdf:subject is an instance of rdf:Property that is used to state the subject of a statement.</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
     <rdfs:label xml:lang="en">subject</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -677,7 +686,7 @@ The date and time that this model represents, i.e. for which the model is (or wa
 [CIM context: 
 Describes the Market Time Unit (MTU), e.g. hourly, 15 min., etc.]</rdfs:comment>
     <cims:dataType rdf:resource="#Duration"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">temporalResolution</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -690,8 +699,8 @@ Describes the Market Time Unit (MTU), e.g. hourly, 15 min., etc.]</rdfs:comment>
 [CIM context: 
 The human readable name of the dataset that can form the instance file name.]</rdfs:comment>
     <cims:dataType rdf:resource="#String"/>
-    <rdfs:domain rdf:resource="https://cim4.eu/ns/dcatcim#Statements"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="https://cim4.eu/ns/dcatcim#Statements"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">title</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -701,6 +710,7 @@ The human readable name of the dataset that can form the instance file name.]</r
   <rdf:Description rdf:about="http://purl.org/dc/terms/type">
     <rdfs:comment>The nature or genre of the resource. Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMI-TYPE]. To describe the file format, physical medium, or dimensions of the resource, use the property Format.</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">type</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -710,6 +720,7 @@ The human readable name of the dataset that can form the instance file name.]</r
   <rdf:Description rdf:about="https://cim4.eu/ns/Metadata-European#usedSettings">
     <rdfs:comment>Reference to a set of parameters describing used settings (e.g. power flow settings, process settings, etc.) applied to the model prior its serialisation.</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">usedSettings</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..n"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -720,7 +731,7 @@ The human readable name of the dataset that can form the instance file name.]</r
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#version">
     <rdfs:comment>The version indicator (name or identifier) of a resource.</rdfs:comment>
     <cims:dataType rdf:resource="#Version"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">version</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -730,7 +741,7 @@ The human readable name of the dataset that can form the instance file name.]</r
   <rdf:Description rdf:about="http://www.w3.org/ns/adms#versionNotes">
     <rdfs:comment>A description of changes between this version and the previous version of the resource.</rdfs:comment>
     <cims:dataType rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#LangString"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">versionNotes</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:0..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>
@@ -742,6 +753,7 @@ The human readable name of the dataset that can form the instance file name.]</r
 [CIM context:
 Reference to an activity or the exact business nature (process, configuration) which produced or uses the model.].</rdfs:comment>
     <cims:dataType rdf:resource="#URI"/>
+    <schema:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:label xml:lang="en">wasGeneratedBy</rdfs:label>
     <cims:multiplicity rdf:resource="http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#M:1..1"/>
     <cims:stereotype rdf:resource="http://iec.ch/TC57/NonStandard/UML#attribute"/>


### PR DESCRIPTION
Backport of #99 to the `ncp-v2-4-2` release branch — cherry-pick of the two commits merged to `main` in 110d92b. The resulting `DatasetMetadata-AP-Voc-RDFS2020.rdf` is identical to the one on `main`.

Fixes on this branch:
- #92 — class linkage restored for the reused external terms, via `schema:domainIncludes`
- #104 — the double `rdfs:domain` on `dcterms:title`/`dcterms:identifier` replaced with two `schema:domainIncludes`

Also brings the README section documenting the `rdfs:domain` / `schema:domainIncludes` convention.
