### PR TITLE
#120 remove typo in GROUP BY section in ShuntCompensator

### DIFF
--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1657,7 +1657,7 @@ equ:ShuntCompensator.maximumSections-numberOfInstancesSparql
             #?nscpointsall cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator  $this .
             #?nscpointsall rdf:type ?typeall .
           }
-        GROUP BY $this ?typeall
+        GROUP BY $this
         }
         $this $PATH ?value .  
         FILTER (?value!=?typesall) .

--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1648,20 +1648,13 @@ equ:ShuntCompensator.maximumSections-numberOfInstancesSparql
     sh:message "The number of NonlinearShuntCompenstorPoint instances associated with a NonlinearShuntCompensator does not equal to ShuntCompensator.maximumSections." ;
     sh:prefixes cim: ;
     sh:select """
-      SELECT  $this ?value ?typesall
+      SELECT  $this (COUNT(?nlscp) AS ?numpoints)
       WHERE {
-        {
-        SELECT $this (COUNT(?typeall) AS ?typesall)
-        WHERE {
-            $this ^cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator/rdf:type ?typeall .
-            #?nscpointsall cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator  $this .
-            #?nscpointsall rdf:type ?typeall .
-          }
-        GROUP BY $this
-        }
-        $this $PATH ?value .  
-        FILTER (?value!=?typesall) .
-      }""" .        
+        $this $PATH ?value .
+        OPTIONAL { $this ^cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator ?nlscp } .
+      }
+      GROUP BY $this ?value
+      HAVING (?numpoints!=?value)""" .        
       
 #equ:Clamp
 #        a               sh:NodeShape ;

--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1657,7 +1657,7 @@ equ:ShuntCompensator.maximumSections-numberOfInstancesSparql
             #?nscpointsall cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator  $this .
             #?nscpointsall rdf:type ?typeall .
           }
-        GROUP BY $this ?typesall
+        GROUP BY $this ?typeall
         }
         $this $PATH ?value .  
         FILTER (?value!=?typesall) .

--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1635,7 +1635,7 @@ equ:NonlinearShuntCompensator  a  sh:NodeShape ;
 equ:ShuntCompensator.maximumSections-numberOfInstances
         a               sh:PropertyShape ;
         sh:sparql       equ:ShuntCompensator.maximumSections-numberOfInstancesSparql ;
-        sh:description  "The number of NonlinearShuntCompenstorPoint instances associated with a NonlinearShuntCompensator shall be equal to ShuntCompensator.maximumSections. " ;
+        sh:description  "The number of NonlinearShuntCompensatorPoint instances associated with a NonlinearShuntCompensator shall be equal to ShuntCompensator.maximumSections. " ;
         sh:name         "C:301:EQ:NonlinearShuntCompensatorPoint:numberOfInstances" ;
         sh:path         cim:ShuntCompensator.maximumSections ;
         sh:group        equ:EQ301UMLvarious ;


### PR DESCRIPTION
Causing validation result HTTP 500 against RelicapGRID.
Now it is 
```turtle
equ:ShuntCompensator.maximumSections-numberOfInstancesSparql
    a         sh:SPARQLConstraint ;  
    sh:message "The number of NonlinearShuntCompenstorPoint instances associated with a NonlinearShuntCompensator does not equal to ShuntCompensator.maximumSections." ;
    sh:prefixes cim: ;
    sh:select """
      SELECT  $this ?value ?typesall
      WHERE {
        {
        SELECT $this (COUNT(?typeall) AS ?typesall)
        WHERE {
            $this ^cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator/rdf:type ?typeall .
            #?nscpointsall cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator  $this .
            #?nscpointsall rdf:type ?typeall .
          }
        GROUP BY $this ?typeall
        }
        $this $PATH ?value .  
        FILTER (?value!=?typesall) .
      }""" . 
```