### PR TITLE
#123 TapChanger value pairs

### DIFF
--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1250,56 +1250,28 @@ equ:GeneratingUnit.nominalP-valueRangePair
 
 equ:PhaseTapChangerLinear.xMin-valueRangePair
         a               sh:PropertyShape ;
-        sh:sparql       equ:PhaseTapChangerLinear.xMin-valueRangePairSparql ;
+        sh:path         cim:PhaseTapChanger.TransformerEnd ;
+        sh:node         [ sh:property [ sh:path      ( [ sh:inversePath cim:PhaseTapChanger.TransformerEnd ] cim:PhaseTapChangerLinear.xMin ) ;
+                                         sh:equals    cim:PowerTransformerEnd.x ] ] ;
         sh:description  "PowerTransformerEnd.x shall be consistent with PhaseTapChangerLinear.xMin and PhaseTapChangerNonLinear.xMin. In case of inconsistency, PowerTransformerEnd.x shall be used." ;
+        sh:message      "Inconsistency between PowerTransformerEnd.x and PhaseTapChangerLinear.xMin." ;
         sh:name         "C:301:EQ:PhaseTapChangerLinear.xMin:valueRangePair" ;
-        sh:path         cim:PhaseTapChangerLinear.xMin ;
         sh:group        equ:EQ301UML ;
         sh:order        72 ;
         sh:severity     sh:Violation .
-        
-    
-equ:PhaseTapChangerLinear.xMin-valueRangePairSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message "Inconsistency between PowerTransformerEnd.x and PhaseTapChangerLinear.xMin." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this ?value
-      WHERE {
-        $this $PATH ?value . 
-        $this cim:PhaseTapChanger.TransformerEnd/cim:PowerTransformerEnd.x ?x . 
-        #$this cim:PhaseTapChanger.TransformerEnd ?theend . 
-        #?theend cim:PowerTransformerEnd.x ?x . 
-        FILTER (?value!=?x ) .        
-      }""" .  
 
 
 equ:PhaseTapChangerNonLinear.xMin-valueRangePair
         a               sh:PropertyShape ;
-        sh:sparql       equ:PhaseTapChangerNonLinear.xMin-valueRangePairSparql ;
+        sh:path         cim:PhaseTapChanger.TransformerEnd ;
+        sh:node         [ sh:property [ sh:path      ( [ sh:inversePath cim:PhaseTapChanger.TransformerEnd ] cim:PhaseTapChangerNonLinear.xMin ) ;
+                                         sh:equals    cim:PowerTransformerEnd.x ] ] ;
         sh:description  "PowerTransformerEnd.x shall be consistent with PhaseTapChangerLinear.xMin and PhaseTapChangerNonLinear.xMin. In case of inconsistency, PowerTransformerEnd.x shall be used." ;
+        sh:message      "Inconsistency between PowerTransformerEnd.x and PhaseTapChangerNonLinear.xMin." ;
         sh:name         "C:301:EQ:PhaseTapChangerNonLinear.xMin:valueRangePair" ;
-        sh:path         cim:PhaseTapChangerNonLinear.xMin ;
         sh:group        equ:EQ301UML ;
         sh:order        73 ;
         sh:severity     sh:Violation .
-        
-    
-equ:PhaseTapChangerNonLinear.xMin-valueRangePairSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message "Inconsistency between PowerTransformerEnd.x and PhaseTapChangerNonLinear.xMin." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this ?value
-      WHERE {
-        $this $PATH ?value . 
-        $this cim:PhaseTapChanger.TransformerEnd/cim:PowerTransformerEnd.x ?x . 
-        #$this cim:PhaseTapChanger.TransformerEnd ?theend . 
-        #?theend cim:PowerTransformerEnd.x ?x . 
-        FILTER (?value!=?x ) .        
-      }""" .  
-
-equ:PowerTransformer-associationNotUsed
         a               sh:PropertyShape ;
         sh:sparql       equ:PowerTransformer-associationNotUsedSparql ;
         sh:path         rdf:type ;

--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1237,31 +1237,15 @@ equ:GeneratingUnit.nominalP  a  sh:NodeShape ;
               
 equ:GeneratingUnit.nominalP-valueRangePair
         a               sh:PropertyShape ;
-        sh:sparql       equ:GeneratingUnit.nominalP-valueRangePairSparql ;
-        sh:description  "The attribute shall be a positive value equal to or less than RotatingMachine.ratedS." ;
+        sh:path         [ sh:inversePath cim:RotatingMachine.GeneratingUnit ] ;
+        sh:node         [ sh:property [ sh:path ( cim:RotatingMachine.GeneratingUnit cim:GeneratingUnit.nominalP ) ;
+                                                          sh:lessThanOrEquals  cim:RotatingMachine.ratedS ] ] ;
+        sh:description  "The attribute shall be equal to or less than RotatingMachine.ratedS." ;
+        sh:message      "The value is greater than RotatingMachine.ratedS for the associated RotatingMachine." ;
         sh:name         "C:301:EQ:GeneratingUnit.nominalP:valueRangePair" ;
-        sh:path         cim:GeneratingUnit.nominalP ;
         sh:group        equ:EQ301UML ;
         sh:order        71 ;
         sh:severity     sh:Violation .
-        
-    
-equ:GeneratingUnit.nominalP-valueRangePairSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message "The value is either negative, zero or greater than RotatingMachine.ratedS." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this ?value
-      WHERE {
-        $this $PATH ?value .
-        BIND(EXISTS{$this $PATH ?v} AS ?hasvalue).
-        #OPTIONAL {$this $PATH ?value }. 
-        $this ^cim:RotatingMachine.GeneratingUnit/cim:RotatingMachine.ratedS ?rateds .
-        BIND(EXISTS{$this ^cim:RotatingMachine.GeneratingUnit/cim:RotatingMachine.ratedS ?r} AS ?hasrateds).
-        #OPTIONAL {$this ^cim:RotatingMachine.GeneratingUnit ?machine }. 
-        #OPTIONAL {?machine cim:RotatingMachine.ratedS ?rateds }. 
-        FILTER (?hasvalue=true && ?hasrateds=true && (?value<=0 || ?value>?rateds) ) .        
-      }""" .         
 
 
 equ:PhaseTapChangerLinear.xMin-valueRangePair

--- a/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
@@ -1272,6 +1272,8 @@ equ:PhaseTapChangerNonLinear.xMin-valueRangePair
         sh:group        equ:EQ301UML ;
         sh:order        73 ;
         sh:severity     sh:Violation .
+
+equ:PowerTransformer-associationNotUsed
         a               sh:PropertyShape ;
         sh:sparql       equ:PowerTransformer-associationNotUsedSparql ;
         sh:path         rdf:type ;

--- a/CGMES/SHACL/61970-600-2_Equipment-AP-Con-Complex-SHACL.ttl
+++ b/CGMES/SHACL/61970-600-2_Equipment-AP-Con-Complex-SHACL.ttl
@@ -72,34 +72,39 @@ eq600:RotatingMachine.ratedS-required
         sh:path         cim:RotatingMachine.ratedS ;
         sh:severity     sh:Violation .
 
-eq600:TapChanger
+eq600:RatioTapChanger.neutralU
         a               sh:NodeShape ;
-        sh:property     eq600:TapChanger.neutralU-valueRangePair ;
-        sh:targetClass  cim:RatioTapChanger , cim:PhaseTapChangerTabular , cim:PhaseTapChangerSymmetrical , cim:PhaseTapChangerAsymmetrical , cim:PhaseTapChangerLinear .
+        sh:property     eq600:RatioTapChanger.neutralU-valueRangePair ;
+        sh:targetClass  cim:RatioTapChanger .
 
-eq600:TapChanger.neutralU-valueRangePair
+eq600:RatioTapChanger.neutralU-valueRangePair
         a               sh:PropertyShape ;
-        sh:sparql       eq600:TapChanger.neutralU-valueRangePairSparql ;
+        sh:path         cim:RatioTapChanger.TransformerEnd ;
+        sh:node         [ sh:property [ sh:path      ( [ sh:inversePath cim:RatioTapChanger.TransformerEnd ] cim:TapChanger.neutralU ) ;
+                                         sh:equals    cim:PowerTransformerEnd.ratedU ] ] ;
         sh:description  "The TapChanger.neutralU shall be the same as PowerTransformerEnd.ratedU." ;
-        sh:name         "C:600:EQ:TapChanger.neutralU:ValueRangePair" ;
-        sh:path         cim:TapChanger.neutralU ;
+        sh:message      "The value is not the same as the PowerTransformerEnd.ratedU." ;
+        sh:name         "C:600:EQ:RatioTapChanger.neutralU:ValueRangePair" ;
         sh:group        eq600:6002EQGroup ;
         sh:order        2 ;
         sh:severity     sh:Violation .
-        
-    
-eq600:TapChanger.neutralU-valueRangePairSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message "The value is not the same as the PowerTransformerEnd.ratedU." ;
-    sh:prefixes cim: ;
-    sh:select """
-        SELECT $this ?value 
-        WHERE {
-        $this $PATH ?value .
-        OPTIONAL {$this cim:RatioTapChanger.TransformerEnd/cim:PowerTransformerEnd.ratedU ?rratedu } .
-        OPTIONAL {$this cim:PhaseTapChanger.TransformerEnd/cim:PowerTransformerEnd.ratedU ?pratedu } .
-        FILTER ((bound(?rratedu) && ?value!=?rratedu) || (bound(?pratedu) && ?value!=?pratedu)).
-        }""" . 
+
+eq600:PhaseTapChanger.neutralU
+        a               sh:NodeShape ;
+        sh:property     eq600:PhaseTapChanger.neutralU-valueRangePair ;
+        sh:targetClass  cim:PhaseTapChangerTabular , cim:PhaseTapChangerSymmetrical , cim:PhaseTapChangerAsymmetrical , cim:PhaseTapChangerLinear .
+
+eq600:PhaseTapChanger.neutralU-valueRangePair
+        a               sh:PropertyShape ;
+        sh:path         cim:PhaseTapChanger.TransformerEnd ;
+        sh:node         [ sh:property [ sh:path      ( [ sh:inversePath cim:PhaseTapChanger.TransformerEnd ] cim:TapChanger.neutralU ) ;
+                                         sh:equals    cim:PowerTransformerEnd.ratedU ] ] ;
+        sh:description  "The TapChanger.neutralU shall be the same as PowerTransformerEnd.ratedU." ;
+        sh:message      "The value is not the same as the PowerTransformerEnd.ratedU." ;
+        sh:name         "C:600:EQ:PhaseTapChanger.neutralU:ValueRangePair" ;
+        sh:group        eq600:6002EQGroup ;
+        sh:order        3 ;
+        sh:severity     sh:Violation .
         
 eq600:SubstationCountShape
        a sh:NodeShape ;
@@ -113,7 +118,7 @@ eq600:Substation-count
         sh:description  "The number of Substation-s shall reflect the design of the power system. Cases of a single Substation in a power system model or having a Substation per VoltageLevel are reported as warnings." ;
         sh:name         "C:600:EQ:Substation:count" ;
         sh:group        eq600:6002EQGroup ;
-        sh:order        3 ;
+        sh:order        4 ;
         sh:severity     sh:Warning .
         
     
@@ -155,7 +160,7 @@ eq600:GeographicalRegion-EQ__4
            sh:group        eq600:6002EQGroup ;
            sh:message      "Muliple GeographicalRegion-s are present." ;
            sh:name         "C:600:EQ:GeographicalRegion:EQ__4" ;
-           sh:order        4 ;
+           sh:order        5 ;
            sh:severity     sh:Violation .
            
 eq600:ReactiveCapabilityCurve
@@ -170,7 +175,7 @@ eq600:ReactiveCapabilityCurve-units
         sh:description  "For a ReactiveCapabilityCurve associated with SynchronousMachine, the Curve.xUnit shall be set to UnitSymbol.W and both Curve.y1Unit and Curve.y2Unit shall be set to UnitSymbol.VAr. As the multiplier is not included in the profile it is defined the same as the multiplier used for datatype ActivePower and ReactivePower, i.e. UnitMultiplier.M." ;
         sh:name         "C:600:EQ:ReactiveCapabilityCurve:units" ;
         sh:group        eq600:6002EQGroup ;
-        sh:order        5 ;
+        sh:order        6 ;
         sh:severity     sh:Violation .
         
     


### PR DESCRIPTION
[Issue 123](https://github.com/entsoe/application-profiles-library/issues/123)

Two files affected:
CGMES/SHACL/61970-301_Equipment-AP-Con-Complex-SHACL.ttl
 - equ:PhaseTapChangerLinear.xMin-valueRangePair
 - equ:PhaseTapChangerNonLinear.xMin-valueRangePair

rewritten without SPARQL, no extra shapes added
 
 CGMES/SHACL/61970-600-2_Equipment-AP-Con-Complex-SHACL.ttl
  - eq600:TapChanger

rewritten without SPARQL, BUT with creation of shape per subclass of TapChanger, because TransformerEnd can have TapChangers of both types simultaneously.

Numeration in the second file is updated to reflect additional shape.

