### PR TITLE
#138-PowerBidDependency.startToStartLagKind

### DIFF
--- a/NCP/SHACL/AvailabilitySchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/AvailabilitySchedule-AP-Con-Complex-SHACL.ttl
@@ -70,105 +70,53 @@ asc:AvailabilityEnabled-associationsSparql
       }""" . 
 
 asc:OutageDependency  a          sh:NodeShape ;
-        sh:property      asc:PeerTemporalDependency.finishToFinishLagKind-required, asc:PeerTemporalDependency.finishToStartLagKind-required, asc:PeerTemporalDependency.overlapKind-required, asc:PeerTemporalDependency.startToStartLagKind-required, asc:PeerTemporalDependency.constraintKind-exclusive;
+        sh:property      asc:PeerTemporalDependency.constraintKind-exclusive;
         sh:targetClass  nc:OutageDependency .      
 
 asc:PeerTemporalDependency.finishToFinishLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
-        sh:sparql       asc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        asc:ASCustomGroup ;
-        sh:name         "C:NC:AS:PeerTemporalDependency.finishToFinishLagKind:required" ;
-        sh:order        7 ;
-        sh:severity     sh:Violation .
-        
-asc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLag ?ftf} AS ?hasftf).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLagKind ?ftfk} AS ?hasftfk).
-    
-        FILTER (?hasftf="true"^^xsd:boolean && ?hasftfk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
+                                sh:name      "C:NC:AS:PeerTemporalDependency.finishToFinishLagKind:required" ;
+                                sh:group     asc:ASCustomGroup ;
+                                sh:order     7 ;
+                                sh:severity  sh:Violation ] .
 
 asc:PeerTemporalDependency.finishToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
-        sh:sparql       asc:PeerTemporalDependency.finishToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        asc:ASCustomGroup ;
-        sh:name         "C:NC:AS:PeerTemporalDependency.finishToStartLagKind:required" ;
-        sh:order        8 ;
-        sh:severity     sh:Violation .
-        
-asc:PeerTemporalDependency.finishToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLag ?fts} AS ?hasfts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLagKind ?ftsk} AS ?hasftsk).
-    
-        FILTER (?hasfts="true"^^xsd:boolean && ?hasftsk="false"^^xsd:boolean).
-      }""" .       
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
+                                sh:name      "C:NC:AS:PeerTemporalDependency.finishToStartLagKind:required" ;
+                                sh:group     asc:ASCustomGroup ;
+                                sh:order     8 ;
+                                sh:severity  sh:Violation ] .
+
 asc:PeerTemporalDependency.overlapKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
-        sh:sparql       asc:PeerTemporalDependency.overlapKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        asc:ASCustomGroup ;
-        sh:name         "C:NC:AS:PeerTemporalDependency.overlapKind:required" ;
-        sh:order        9 ;
-        sh:severity     sh:Violation .
-        
-asc:PeerTemporalDependency.overlapKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlap ?op} AS ?hasop).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlapKind ?opk} AS ?hasopk).
-    
-        FILTER (?hasop="true"^^xsd:boolean && ?hasopk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
+                                sh:name      "C:NC:AS:PeerTemporalDependency.overlapKind:required" ;
+                                sh:group     asc:ASCustomGroup ;
+                                sh:order     9 ;
+                                sh:severity  sh:Violation ] .
 
 asc:PeerTemporalDependency.startToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
-        sh:sparql       asc:PeerTemporalDependency.startToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        asc:ASCustomGroup ;
-        sh:name         "C:NC:AS:PeerTemporalDependency.startToStartLagKind:required" ;
-        sh:order        10 ;
-        sh:severity     sh:Violation .
-        
-asc:PeerTemporalDependency.startToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLag ?sts} AS ?hassts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLagKind ?stsk} AS ?hasstsk).
-    
-        FILTER (?hassts="true"^^xsd:boolean && ?hasstsk="false"^^xsd:boolean).
-      }""" .         
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
+                                sh:name      "C:NC:AS:PeerTemporalDependency.startToStartLagKind:required" ;
+                                sh:group     asc:ASCustomGroup ;
+                                sh:order     10 ;
+                                sh:severity  sh:Violation ] .
+
 asc:PeerTemporalDependency.constraintKind-exclusive
         a               sh:PropertyShape ;
         sh:description  "If PeerTemporalDependency.constraintKind is set to DependencyConstraintKind.exclusive, the following attributes shall not be defined: PeerTemporalDependency.overlap, PeerTemporalDependency.startToStartLag, PeerTemporalDependency.finishToStartLag, PeerTemporalDependency.finishToFinishLag." ;

--- a/NCP/SHACL/AvailabilitySchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/AvailabilitySchedule-AP-Con-Complex-SHACL.ttl
@@ -78,6 +78,7 @@ asc:PeerTemporalDependency.finishToFinishLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
                                 sh:name      "C:NC:AS:PeerTemporalDependency.finishToFinishLagKind:required" ;
                                 sh:group     asc:ASCustomGroup ;
@@ -89,6 +90,7 @@ asc:PeerTemporalDependency.finishToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
                                 sh:name      "C:NC:AS:PeerTemporalDependency.finishToStartLagKind:required" ;
                                 sh:group     asc:ASCustomGroup ;
@@ -100,6 +102,7 @@ asc:PeerTemporalDependency.overlapKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
                                 sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
                                 sh:name      "C:NC:AS:PeerTemporalDependency.overlapKind:required" ;
                                 sh:group     asc:ASCustomGroup ;
@@ -111,6 +114,7 @@ asc:PeerTemporalDependency.startToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
                                 sh:name      "C:NC:AS:PeerTemporalDependency.startToStartLagKind:required" ;
                                 sh:group     asc:ASCustomGroup ;

--- a/NCP/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
+++ b/NCP/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
@@ -1036,7 +1036,7 @@ dm:Dataset  rdf:type  sh:NodeShape ;
         sh:targetClass  dcat:Dataset , dcatcim:DifferenceSet.    
     
 dm:DifferenceSet  rdf:type  sh:NodeShape ;
-        sh:property     dm:forwardReverse-dependency,dm:reverseDifferencePreviousVersion-dependency ;
+        sh:property     dm:forwardReverse-dependency ;
         sh:targetClass  dcatcim:DifferenceSet.    
     
 
@@ -1371,25 +1371,12 @@ dm:forwardReverse-dependencySparql
         }""" .
     
 dm:reverseDifferencePreviousVersion-dependency
-        a               sh:PropertyShape ;
-        sh:sparql       dm:reverseDifferencePreviousVersion-dependencySparql ;
-        sh:description  "If dcatcim:reverseDifference exists there must be a dcat:previousVersion." ;
-        sh:name         "reverseDifferencePreviousVersion-dependency" ;
-        sh:path         rdf:type;
-        sh:group        dm:CardinalityGroupCustom ;
-        sh:order        19 ;
-        sh:severity     sh:Violation .
-        
-    
-dm:reverseDifferencePreviousVersion-dependencySparql
-    a         sh:SPARQLConstraint ;  
-    sh:message "dcatcim:reverseDifference exists but dcat:previousVersion is not present." ;
-    sh:prefixes cim: ;
-    sh:select """
-        SELECT $this ?value 
-        WHERE {
-    BIND(EXISTS{$this dcatcim:reverseDifference ?value} AS ?hasrd).
-    BIND(EXISTS{$this dcat:previousVersion ?value1} AS ?haspv).
-
-        FILTER (?hasrd="true"^^xsd:boolean && ?haspv="false"^^xsd:boolean).
-        }""" .      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  dcatcim:reverseDifference ;
+        sh:property          [ sh:path      dcat:previousVersion ;
+                                sh:minCount  1 ;
+                                sh:message   "dcatcim:reverseDifference exists but dcat:previousVersion is not present." ;
+                                sh:name      "reverseDifferencePreviousVersion-dependency" ;
+                                sh:group     dm:CardinalityGroupCustom ;
+                                sh:order     19 ;
+                                sh:severity  sh:Violation ] .

--- a/NCP/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
+++ b/NCP/SHACL/DatasetMetadata-AP-Con-SHACL.ttl
@@ -1375,6 +1375,7 @@ dm:reverseDifferencePreviousVersion-dependency
         sh:targetSubjectsOf  dcatcim:reverseDifference ;
         sh:property          [ sh:path      dcat:previousVersion ;
                                 sh:minCount  1 ;
+                                sh:description  "If dcatcim:reverseDifference exists there must be a dcat:previousVersion." ;
                                 sh:message   "dcatcim:reverseDifference exists but dcat:previousVersion is not present." ;
                                 sh:name      "reverseDifferencePreviousVersion-dependency" ;
                                 sh:group     dm:CardinalityGroupCustom ;

--- a/NCP/SHACL/EquipmentReliability-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/EquipmentReliability-AP-Con-Complex-SHACL.ttl
@@ -530,6 +530,7 @@ erc:PeerTemporalDependency.finishToFinishLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
                                 sh:name      "C:NC:ER:PeerTemporalDependency.finishToFinishLagKind:required" ;
                                 sh:group     erc:ERgroup ;
@@ -541,6 +542,7 @@ erc:PeerTemporalDependency.finishToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
                                 sh:name      "C:NC:ER:PeerTemporalDependency.finishToStartLagKind:required" ;
                                 sh:group     erc:ERgroup ;
@@ -552,6 +554,7 @@ erc:PeerTemporalDependency.overlapKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
                                 sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
                                 sh:name      "C:NC:ER:PeerTemporalDependency.overlapKind:required" ;
                                 sh:group     erc:ERgroup ;
@@ -563,6 +566,7 @@ erc:PeerTemporalDependency.startToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
                                 sh:name      "C:NC:ER:PeerTemporalDependency.startToStartLagKind:required" ;
                                 sh:group     erc:ERgroup ;

--- a/NCP/SHACL/EquipmentReliability-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/EquipmentReliability-AP-Con-Complex-SHACL.ttl
@@ -522,105 +522,53 @@ erc:BoundaryPointBorder-requiredAssociationSparql
     """ .
 	
 erc:ThermalGeneratingUnitDependency  a          sh:NodeShape ;
-        sh:property      erc:PeerTemporalDependency.finishToFinishLagKind-required, erc:PeerTemporalDependency.finishToStartLagKind-required, erc:PeerTemporalDependency.overlapKind-required, erc:PeerTemporalDependency.startToStartLagKind-required, erc:PeerTemporalDependency.constraintKind-exclusive;
+        sh:property      erc:PeerTemporalDependency.constraintKind-exclusive;
         sh:targetClass  nc:ThermalGeneratingUnitDependency .      
 
 erc:PeerTemporalDependency.finishToFinishLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
-        sh:sparql       erc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        erc:ERgroup ;
-        sh:name         "C:NC:ER:PeerTemporalDependency.finishToFinishLagKind:required" ;
-        sh:order        7 ;
-        sh:severity     sh:Violation .
-        
-erc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLag ?ftf} AS ?hasftf).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLagKind ?ftfk} AS ?hasftfk).
-    
-        FILTER (?hasftf="true"^^xsd:boolean && ?hasftfk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
+                                sh:name      "C:NC:ER:PeerTemporalDependency.finishToFinishLagKind:required" ;
+                                sh:group     erc:ERgroup ;
+                                sh:order     7 ;
+                                sh:severity  sh:Violation ] .
 
 erc:PeerTemporalDependency.finishToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
-        sh:sparql       erc:PeerTemporalDependency.finishToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        erc:ERgroup ;
-        sh:name         "C:NC:ER:PeerTemporalDependency.finishToStartLagKind:required" ;
-        sh:order        8 ;
-        sh:severity     sh:Violation .
-        
-erc:PeerTemporalDependency.finishToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLag ?fts} AS ?hasfts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLagKind ?ftsk} AS ?hasftsk).
-    
-        FILTER (?hasfts="true"^^xsd:boolean && ?hasftsk="false"^^xsd:boolean).
-      }""" .       
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
+                                sh:name      "C:NC:ER:PeerTemporalDependency.finishToStartLagKind:required" ;
+                                sh:group     erc:ERgroup ;
+                                sh:order     8 ;
+                                sh:severity  sh:Violation ] .
+
 erc:PeerTemporalDependency.overlapKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
-        sh:sparql       erc:PeerTemporalDependency.overlapKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        erc:ERgroup ;
-        sh:name         "C:NC:ER:PeerTemporalDependency.overlapKind:required" ;
-        sh:order        9 ;
-        sh:severity     sh:Violation .
-        
-erc:PeerTemporalDependency.overlapKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlap ?op} AS ?hasop).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlapKind ?opk} AS ?hasopk).
-    
-        FILTER (?hasop="true"^^xsd:boolean && ?hasopk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
+                                sh:name      "C:NC:ER:PeerTemporalDependency.overlapKind:required" ;
+                                sh:group     erc:ERgroup ;
+                                sh:order     9 ;
+                                sh:severity  sh:Violation ] .
 
 erc:PeerTemporalDependency.startToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
-        sh:sparql       erc:PeerTemporalDependency.startToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        erc:ERgroup ;
-        sh:name         "C:NC:ER:PeerTemporalDependency.startToStartLagKind:required" ;
-        sh:order        10 ;
-        sh:severity     sh:Violation .
-        
-erc:PeerTemporalDependency.startToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLag ?sts} AS ?hassts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLagKind ?stsk} AS ?hasstsk).
-    
-        FILTER (?hassts="true"^^xsd:boolean && ?hasstsk="false"^^xsd:boolean).
-      }""" .         
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
+                                sh:name      "C:NC:ER:PeerTemporalDependency.startToStartLagKind:required" ;
+                                sh:group     erc:ERgroup ;
+                                sh:order     10 ;
+                                sh:severity  sh:Violation ] .
+
 erc:PeerTemporalDependency.constraintKind-exclusive
         a               sh:PropertyShape ;
         sh:description  "If PeerTemporalDependency.constraintKind is set to DependencyConstraintKind.exclusive, the following attributes shall not be defined: PeerTemporalDependency.overlap, PeerTemporalDependency.startToStartLag, PeerTemporalDependency.finishToStartLag, PeerTemporalDependency.finishToFinishLag." ;

--- a/NCP/SHACL/StateInstructionSchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/StateInstructionSchedule-AP-Con-Complex-SHACL.ttl
@@ -233,6 +233,7 @@ sisc:PeerTemporalDependency.finishToFinishLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
                                 sh:name      "C:NC:SIS:PeerTemporalDependency.finishToFinishLagKind:required" ;
                                 sh:group     sisc:SISCustomGroup ;
@@ -244,6 +245,7 @@ sisc:PeerTemporalDependency.finishToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
                                 sh:name      "C:NC:SIS:PeerTemporalDependency.finishToStartLagKind:required" ;
                                 sh:group     sisc:SISCustomGroup ;
@@ -255,6 +257,7 @@ sisc:PeerTemporalDependency.overlapKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
                                 sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
                                 sh:name      "C:NC:SIS:PeerTemporalDependency.overlapKind:required" ;
                                 sh:group     sisc:SISCustomGroup ;
@@ -266,6 +269,7 @@ sisc:PeerTemporalDependency.startToStartLagKind-required
         sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
         sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
                                 sh:minCount  1 ;
+                                sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
                                 sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
                                 sh:name      "C:NC:SIS:PeerTemporalDependency.startToStartLagKind:required" ;
                                 sh:group     sisc:SISCustomGroup ;

--- a/NCP/SHACL/StateInstructionSchedule-AP-Con-Complex-SHACL.ttl
+++ b/NCP/SHACL/StateInstructionSchedule-AP-Con-Complex-SHACL.ttl
@@ -225,105 +225,53 @@ sisc:PowerBidScheduleTimePoint-attributesSparql
       }""" .     
       
 sisc:PowerBidDependency  a          sh:NodeShape ;
-        sh:property      sisc:PeerTemporalDependency.finishToFinishLagKind-required, sisc:PeerTemporalDependency.finishToStartLagKind-required, sisc:PeerTemporalDependency.overlapKind-required, sisc:PeerTemporalDependency.startToStartLagKind-required, sisc:PeerTemporalDependency.constraintKind-exclusive;
+        sh:property      sisc:PeerTemporalDependency.constraintKind-exclusive;
         sh:targetClass  nc:PowerBidDependency .      
 
 sisc:PeerTemporalDependency.finishToFinishLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToFinishLag is present PeerTemporalDependency.finishToFinishLagKind is required." ;
-        sh:sparql       sisc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        sisc:SISCustomGroup ;
-        sh:name         "C:NC:SIS:PeerTemporalDependency.finishToFinishLagKind:required" ;
-        sh:order        7 ;
-        sh:severity     sh:Violation .
-        
-sisc:PeerTemporalDependency.finishToFinishLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLag ?ftf} AS ?hasftf).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToFinishLagKind ?ftfk} AS ?hasftfk).
-    
-        FILTER (?hasftf="true"^^xsd:boolean && ?hasftfk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToFinishLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToFinishLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToFinishLagKind is missing when PeerTemporalDependency.finishToFinishLag is present." ;
+                                sh:name      "C:NC:SIS:PeerTemporalDependency.finishToFinishLagKind:required" ;
+                                sh:group     sisc:SISCustomGroup ;
+                                sh:order     7 ;
+                                sh:severity  sh:Violation ] .
 
 sisc:PeerTemporalDependency.finishToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.finishToStartLag is present PeerTemporalDependency.finishToStartLagKind is required." ;
-        sh:sparql       sisc:PeerTemporalDependency.finishToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        sisc:SISCustomGroup ;
-        sh:name         "C:NC:SIS:PeerTemporalDependency.finishToStartLagKind:required" ;
-        sh:order        8 ;
-        sh:severity     sh:Violation .
-        
-sisc:PeerTemporalDependency.finishToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLag ?fts} AS ?hasfts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.finishToStartLagKind ?ftsk} AS ?hasftsk).
-    
-        FILTER (?hasfts="true"^^xsd:boolean && ?hasftsk="false"^^xsd:boolean).
-      }""" .       
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.finishToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.finishToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.finishToStartLagKind is missing when PeerTemporalDependency.finishToStartLag is present." ;
+                                sh:name      "C:NC:SIS:PeerTemporalDependency.finishToStartLagKind:required" ;
+                                sh:group     sisc:SISCustomGroup ;
+                                sh:order     8 ;
+                                sh:severity  sh:Violation ] .
+
 sisc:PeerTemporalDependency.overlapKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.overlap is present PeerTemporalDependency.overlapKind is required." ;
-        sh:sparql       sisc:PeerTemporalDependency.overlapKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        sisc:SISCustomGroup ;
-        sh:name         "C:NC:SIS:PeerTemporalDependency.overlapKind:required" ;
-        sh:order        9 ;
-        sh:severity     sh:Violation .
-        
-sisc:PeerTemporalDependency.overlapKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlap ?op} AS ?hasop).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.overlapKind ?opk} AS ?hasopk).
-    
-        FILTER (?hasop="true"^^xsd:boolean && ?hasopk="false"^^xsd:boolean).
-      }""" .     
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.overlap ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.overlapKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.overlapKind is missing when PeerTemporalDependency.overlap is present." ;
+                                sh:name      "C:NC:SIS:PeerTemporalDependency.overlapKind:required" ;
+                                sh:group     sisc:SISCustomGroup ;
+                                sh:order     9 ;
+                                sh:severity  sh:Violation ] .
 
 sisc:PeerTemporalDependency.startToStartLagKind-required
-        a               sh:PropertyShape ;
-        sh:description  "If PeerTemporalDependency.startToStartLag is present PeerTemporalDependency.startToStartLagKind is required." ;
-        sh:sparql       sisc:PeerTemporalDependency.startToStartLagKind-requiredSparql ;
-        sh:path         rdf:type ;
-        sh:group        sisc:SISCustomGroup ;
-        sh:name         "C:NC:SIS:PeerTemporalDependency.startToStartLagKind:required" ;
-        sh:order        10 ;
-        sh:severity     sh:Violation .
-        
-sisc:PeerTemporalDependency.startToStartLagKind-requiredSparql
-    a         sh:SPARQLConstraint ;  
-    sh:message      "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
-    sh:prefixes cim: ;
-    sh:select """
-      SELECT  $this  
-      WHERE {  
-     
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLag ?sts} AS ?hassts).  
-    BIND(EXISTS{$this nc:PeerTemporalDependency.startToStartLagKind ?stsk} AS ?hasstsk).
-    
-        FILTER (?hassts="true"^^xsd:boolean && ?hasstsk="false"^^xsd:boolean).
-      }""" .         
-      
+        a                    sh:NodeShape ;
+        sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
+        sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
+                                sh:minCount  1 ;
+                                sh:message   "PeerTemporalDependency.startToStartLagKind is missing when PeerTemporalDependency.startToStartLag is present." ;
+                                sh:name      "C:NC:SIS:PeerTemporalDependency.startToStartLagKind:required" ;
+                                sh:group     sisc:SISCustomGroup ;
+                                sh:order     10 ;
+                                sh:severity  sh:Violation ] .
+
 sisc:PeerTemporalDependency.constraintKind-exclusive
         a               sh:PropertyShape ;
         sh:description  "If PeerTemporalDependency.constraintKind is set to DependencyConstraintKind.exclusive, the following attributes shall not be defined: PeerTemporalDependency.overlap, PeerTemporalDependency.startToStartLag, PeerTemporalDependency.finishToStartLag, PeerTemporalDependency.finishToFinishLag." ;


### PR DESCRIPTION
also 
```turtle
sisc:PeerTemporalDependency.startToStartLagKind-required
        a                    sh:NodeShape ;
        sh:targetSubjectsOf  nc:PeerTemporalDependency.startToStartLag ;
        sh:property          [ sh:path      nc:PeerTemporalDependency.startToStartLagKind ;
                                sh:minCount  1 ;
                                sh:message   "..." ] .
```     
and other, see issue #138 